### PR TITLE
Revert maintenance mode urls not working in our setup

### DIFF
--- a/fm_eventmanager/urls.py
+++ b/fm_eventmanager/urls.py
@@ -7,11 +7,10 @@ from django.views.generic import RedirectView
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"^$", RedirectView.as_view(url="registration")),
     url(r"^registration/", include("registration.urls", namespace="registration")),
     url(r"^admin/", admin.site.urls),
     url(r"^u2f/", include(django_u2f.urls, namespace="u2f")),
-    url(r"^maintenance-mode/", include("maintenance_mode.urls")),
+    url(r"^$", RedirectView.as_view(url="registration")),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Always results in a 404 on the production server for `/apis/maintenance_mode/off/` when maintenance mode was manually turned on.