### PR TITLE
make registrationToken read only and displayed on badge as well

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -523,7 +523,7 @@ class StaffAdmin(ImportExportModelAdmin):
     list_filter = ("event", "department")
     search_fields = ["attendee__email", "attendee__lastName", "attendee__firstName"]
     resource_class = StaffResource
-    readonly_fields = ["get_email", "get_badge", "get_badge_id"]
+    readonly_fields = ["get_email", "get_badge", "get_badge_id", "registrationToken"]
     fieldsets = (
         (
             None,
@@ -952,6 +952,7 @@ class BadgeInline(NestedTabularInline):
     ]
     readonly_fields = [
         "get_age_range",
+        "registrationToken",
     ]
 
     def get_age_range(self, obj):

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -375,7 +375,7 @@ class DealerAdmin(NestedModelAdmin, ImportExportModelAdmin):
         send_assistant_form_email,
         send_payment_email,
     ]
-    readonly_fields = ["get_email"]
+    readonly_fields = ["get_email", "registrationToken"]
     fieldsets = (
         (
             None,
@@ -1060,7 +1060,7 @@ class BadgeAdmin(NestedModelAdmin, ImportExportModelAdmin):
         "badgeName",
         "badgeNumber",
     ]
-    readonly_fields = ["get_age_range"]
+    readonly_fields = ["get_age_range", "registrationToken"]
     actions = [
         assign_badge_numbers,
         print_badges,
@@ -1080,7 +1080,7 @@ class BadgeAdmin(NestedModelAdmin, ImportExportModelAdmin):
                 "fields": (
                     "printed",
                     ("badgeName", "badgeNumber", "get_age_range"),
-                    ("registeredDate", "event"),
+                    ("registeredDate", "event", "registrationToken"),
                     "attendee",
                 )
             },


### PR DESCRIPTION
registrationToken exists on Badge, Dealer, and Staff objects and is used to make locate the correct record when doing an attendee upgrade, the entire dealer process after approval, and staff interactions. this field was missing from BadgeAdmin, but was added to BadgeAdmin inlines, so youd have to go through an order object just to view it. meanwhile, since its generated uniquely for each object and only used to refer to that object, it doesnt need to be editable as in practice it would never change