### PR TITLE
Dozer/calculate unpaid assistants

### DIFF
--- a/registration/models.py
+++ b/registration/models.py
@@ -582,6 +582,10 @@ class Dealer(models.Model):
         partnercount = self.dealerasst_set.count()
         return partnercount
 
+    def getUnpaidPartnerCount(self):
+        unpaidpartnercount = dealer.dealerasst_set.all().filter(paid=False).count()
+        return unpaidpartnercount
+		
     def paidTotal(self):
         total = 0
         badge = self.getBadge()

--- a/registration/models.py
+++ b/registration/models.py
@@ -583,7 +583,7 @@ class Dealer(models.Model):
         return partnercount
 
     def getUnpaidPartnerCount(self):
-        unpaidpartnercount = dealer.dealerasst_set.all().filter(paid=False).count()
+        unpaidpartnercount = self.dealerasst_set.all().filter(paid=False).count()
         return unpaidpartnercount
 		
     def paidTotal(self):

--- a/registration/templates/registration/dealer/dealer-checkout.html
+++ b/registration/templates/registration/dealer/dealer-checkout.html
@@ -110,10 +110,10 @@ var paymentForm = new SqPaymentForm({
 				</div>
 			</div>
 
-			{% if dealer.getPartnerCount > 0 %}
+			{% if dealer.getUnpaidPartnerCount > 0 %}
 			<div class="row">
-				<div class="col-sm-6 col-sm-offset-1">Partners x{{ dealer.getPartnerCount }}</div>
-				<div class="col-sm-2">${{dealer.getPartnerCount|mul:55}}.00</div>
+				<div class="col-sm-6 col-sm-offset-1">Partners x{{ dealer.getUnpaidPartnerCount }}</div>
+				<div class="col-sm-2">${{dealer.getUnpaidPartnerCount|mul:55}}.00</div>
 				<div class="col-sm-2">
 				</div>
 			</div>

--- a/registration/templates/registration/emails/dealer/payment.html
+++ b/registration/templates/registration/emails/dealer/payment.html
@@ -13,8 +13,8 @@
 {% if dealer.needWifi %}
 <tr><td>Wi-Fi Access</td><td>$50.00</td></tr>
 {% endif %}
-{% if dealer.getPartnerCount > 0%}
-<tr><td>Partners x{{dealer.getPartnerCount}}</td><td>${{dealer.getPartnerCount|mul:55}}.00</td></tr>
+{% if dealer.getUnpaidPartnerCount > 0%}
+<tr><td>Partners x{{dealer.getUnpaidPartnerCount}}</td><td>${{dealer.getUnpaidPartnerCount|mul:55}}.00</td></tr>
 {% endif %}
 {% if dealer.asstBreakfast%}
 <tr><td>Partner Breakfast x{{dealer.getPartnerCount}}</td><td>${{dealer.getPartnerCount|mul:60}}.00</td></tr>

--- a/registration/templates/registration/emails/dealer/payment.txt
+++ b/registration/templates/registration/emails/dealer/payment.txt
@@ -13,9 +13,9 @@ Table Type - {{dealer.tableSize}}:  ${{dealer.tableSize.basePrice}}
 {% if dealer.needWifi %}
 Wi-Fi Access:  $50.00
 {% endif %}
-{% if dealer.getPartnerCount > 0%}
+{% if dealer.getUnpaidPartnerCount > 0%}
 
-Partners x{{dealer.getPartnerCount}}:  ${{dealer.getPartnerCount|mul:55}}.00
+Partners x{{dealer.getUnpaidPartnerCount}}:  ${{dealer.getUnpaidPartnerCount|mul:55}}.00
 {% endif %}
 {% if dealer.asstBreakfast%}
 Partner Breakfast x{{dealer.getPartnerCount}}:  ${{dealer.getPartnerCount|mul:60}}.00

--- a/registration/views/dealers.py
+++ b/registration/views/dealers.py
@@ -311,7 +311,7 @@ def add_assistants_checkout(request):
 
     if status:
         # Payment succeeded - Mark assistants as paid
-        for for assistant in dealer.dealerasst_set.all().filter(paid=False):
+        for assistant in dealer.dealerasst_set.all().filter(paid=False):
             assistant.paid = True
             assistant.save()
 
@@ -652,6 +652,7 @@ def getDealerTotal(orderItems, discount, dealer):
                     )
             else:
                 itemSubTotal += option.option.optionPrice
+    unpaidPartnerCount = dealer.getUnpaidPartnerCount()
     partnerCount = dealer.getPartnerCount()
     partnerBreakfast = 0
     if partnerCount > 0 and dealer.asstBreakfast:
@@ -667,7 +668,7 @@ def getDealerTotal(orderItems, discount, dealer):
         itemSubTotal = getDiscountTotal(discount, itemSubTotal)
     total = (
         itemSubTotal
-        + 55 * partnerCount
+        + 55 * unpaidPartnerCount
         + partnerBreakfast
         + dealer.tableSize.basePrice
         + wifi

--- a/registration/views/dealers.py
+++ b/registration/views/dealers.py
@@ -288,7 +288,7 @@ def add_assistants_checkout(request):
                 }
             )
 
-    unpaid_partner_count = dealer.dealerasst_set.all().filter(paid=False).count()
+    unpaid_partner_count = dealer.getUnpaidPartnerCount()
 
     # FIXME: remove hardcoded costs
     total = Decimal(55 * unpaid_partner_count)
@@ -311,7 +311,7 @@ def add_assistants_checkout(request):
 
     if status:
         # Payment succeeded - Mark assistants as paid
-        for assistant in dealer.dealerasst_set.all():
+        for for assistant in dealer.dealerasst_set.all().filter(paid=False):
             assistant.paid = True
             assistant.save()
 


### PR DESCRIPTION
Dealer checkout now behaves properly when an attendee who already paid is added as an assistant. Confirmed with scenarios of 1 unpaid assistant, 1 paid assistant, and 1 of each.