### PR TITLE
Add a more obvious noscript tag advising js is required

### DIFF
--- a/registration/templates/registration/dealer/dealer-form.html
+++ b/registration/templates/registration/dealer/dealer-form.html
@@ -43,9 +43,12 @@
     </div>
 </div>
 
-<form class="form-horizontal" role="form" data-toggle="validator">
+<noscript>
+  <h1>Javascript is required to use this form.</h1>
+</noscript>
+<form class="form-horizontal" role="form" data-toggle="validator" style="display: none">
     <div class="tab-content">
-        <div role="tabpanel" class="tab-pane fade in active" id="personal">
+        <div role="tabpanel" class="tab-pane active" id="personal">
             <h1>Dealer Registration - {{event}}</h1>
             <p>Welcome to the registration system. To continue, enter your information below.</p>
 
@@ -275,6 +278,10 @@
 
     $("#next-optional").click(function() {
         window.scrollTo(0, 0);
+    });
+
+    $(document).ready(function () {
+       $("form").fadeIn();
     });
 
 

--- a/registration/templates/registration/dealer/dealerasst-add.html
+++ b/registration/templates/registration/dealer/dealerasst-add.html
@@ -123,8 +123,10 @@ var paymentForm = new SqPaymentForm({
             convenience, but cannot be edited here.
         </div>
 
-
-        <form class="form-horizontal" role="form" data-toggle="validator">
+        <noscript>
+          <h1>Javascript is required to use this form.</h1>
+        </noscript>
+        <form class="form-horizontal" role="form" data-toggle="validator" style="display: none">
 
             <div class="form-group">
                 <label for="tables" class="col-sm-3 control-label">Table Type</label>
@@ -310,18 +312,18 @@ var paymentForm = new SqPaymentForm({
 
 
 {% block javascript %}
-<script type="text/javascript">
-    var DEALER_EMAIL = "{{event.dealerEmail}}";
-    var URL_DONE_AST_DEALER = "{% url 'registration:doneAsstDealer' %}";
-    var URL_ADD_ASSISTANTS_CHECKOUT = "{% url 'registration:add_assistants_checkout' %}";
-    var dealer_id = {{dealer.id}};
-    var maxPartners = {{dealer.tableSize.partnerMax}};
-    var dealer_assistants = {{json_assistants|safe}};
-	$( "body" ).ready(function() {
-		$("#state").val("{{attendee.state}}");
-		$("#country").val("{{attendee.country}}");
-	});
-
-</script>
-<script src="{% static 'js/dealers/dealerasst-add.js' %}"></script>
+  <script type="text/javascript">
+      var DEALER_EMAIL = "{{event.dealerEmail}}";
+      var URL_DONE_AST_DEALER = "{% url 'registration:doneAsstDealer' %}";
+      var URL_ADD_ASSISTANTS_CHECKOUT = "{% url 'registration:add_assistants_checkout' %}";
+      var dealer_id = {{dealer.id}};
+      var maxPartners = {{dealer.tableSize.partnerMax}};
+      var dealer_assistants = {{json_assistants|safe}};
+      $("body").ready(function () {
+          $("form").fadeIn();
+          $("#state").val("{{attendee.state}}");
+          $("#country").val("{{attendee.country}}");
+      });
+  </script>
+  <script src="{% static 'js/dealers/dealerasst-add.js' %}"></script>
 {% endblock %}

--- a/registration/templates/registration/registration-form.html
+++ b/registration/templates/registration/registration-form.html
@@ -28,7 +28,10 @@
   </div>
 </div>
 
-    <form class="form-horizontal" role="form" data-toggle="validator">
+    <noscript>
+      <h1>Javascript is required to use this form.</h1>
+    </noscript>
+    <form class="form-horizontal" role="form" data-toggle="validator" style="display: none">
     <div class="tab-content">
     <div role="tabpanel" class="tab-pane fade in active" id="personal">
         <h1>Pre-Register for {{event}}!</h1>
@@ -206,6 +209,7 @@
     };
 
     $( "body" ).ready(function() {
+        $("form").fadeIn();
         $.getJSON("{% url 'registration:pricelevels' %}", function(data) {
             levelData = data;
             $.each( data, function( key, val ) {


### PR DESCRIPTION
When people don't have js on but the form is visible, it ends up being a GET request which manifests itself in a 502 for some reason.