### PR TITLE
recategorize errors

### DIFF
--- a/registration/views/dealers.py
+++ b/registration/views/dealers.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime
 
 from django.forms import model_to_dict
-from django.http import HttpResponse, HttpResponseServerError, JsonResponse
+from django.http import HttpResponse, HttpResponseServerError, HttpResponseNotFound, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 
@@ -113,7 +113,7 @@ def findDealer(request):
             attendee__email__iexact=email, registrationToken=token
         )
     except Dealer.DoesNotExist:
-        return HttpResponseServerError("No Dealer Found " + email)
+        return HttpResponseNotFound("No Dealer Found " + email)
 
     request.session["dealer_id"] = dealer.id
     return JsonResponse({"success": True, "message": "DEALER"})
@@ -135,7 +135,7 @@ def find_dealer_to_add_assistant_post(request):
             attendee__email__iexact=email, registrationToken=token
         )
     except Dealer.DoesNotExist:
-        return HttpResponseServerError("No dealer found")
+        return HttpResponseNotFound("No dealer found")
 
     request.session["dealer_id"] = dealer.pk
     return JsonResponse(
@@ -157,7 +157,7 @@ def findAsstDealer(request):
             email__iexact=email, registrationToken=token
         )
     except DealerAsst.DoesNotExist:
-        return HttpResponseServerError("No assistant dealer found")
+        return HttpResponseNotFound("No assistant dealer found")
 
     # Check if they've already registered:
     if dealer_assistant.attendee is not None:

--- a/registration/views/staff.py
+++ b/registration/views/staff.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime
 
 from django.forms import model_to_dict
-from django.http import HttpResponseServerError, JsonResponse
+from django.http import HttpResponseServerError, HttpResponseNotFound, JsonResponse
 from django.shortcuts import render
 
 import registration.emails
@@ -29,7 +29,7 @@ def findNewStaff(request):
 
         token = TempToken.objects.get(email__iexact=email, token=token)
         if not token:
-            return HttpResponseServerError("No Staff Found")
+            return HttpResponseNotFound("No Staff Found")
 
         if token.validUntil < timezone.now():
             return HttpResponseServerError("Invalid Token")
@@ -155,7 +155,7 @@ def findStaff(request):
             attendee__email__iexact=email, registrationToken=token
         )
         if not staff:
-            return HttpResponseServerError("No Staff Found")
+            return HttpResponseNotFound("No Staff Found")
 
         request.session["staff_id"] = staff.id
         return JsonResponse({"success": True, "message": "STAFF"})


### PR DESCRIPTION
Several things that are simple Not Founds, defined by the venerable HTTP 404 have been told to raise 500 errors, causing very chatty and useless error reporting