### PR TITLE
expose maintenance switch

### DIFF
--- a/fm_eventmanager/settings.py.devel
+++ b/fm_eventmanager/settings.py.devel
@@ -177,6 +177,8 @@ USE_TZ = True
 
 SITE_ID = 1
 
+MAINTENANCE_MODE = False
+MAINTENANCE_MODE_STATE_FILE_PATH = "/app/fm_eventmanager/maintenance_mode_state.txt"
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
 MAINTENANCE_MODE_IGNORE_URLS = ("^/u2f/",)
 

--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -298,6 +298,7 @@ IDEMPOTENCY_KEY = {
 
 }
 
+MAINTENANCE_MODE = eval_bool(os.getenv('MAINTENANCE_MODE', 'False'))
 MAINTENANCE_MODE_STATE_FILE_PATH = "/app/fm_eventmanager/maintenance_mode_state.txt"
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
 MAINTENANCE_MODE_IGNORE_URLS = ("^/u2f/",)

--- a/fm_eventmanager/settings.py.example
+++ b/fm_eventmanager/settings.py.example
@@ -147,6 +147,8 @@ USE_TZ = True
 
 SITE_ID = 1
 
+MAINTENANCE_MODE = False
+MAINTENANCE_MODE_STATE_FILE_PATH = "/app/fm_eventmanager/maintenance_mode_state.txt"
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
 MAINTENANCE_MODE_IGNORE_URLS = ("^/u2f/",)
 

--- a/fm_eventmanager/settings.py.travis
+++ b/fm_eventmanager/settings.py.travis
@@ -177,6 +177,8 @@ USE_TZ = True
 
 SITE_ID = 1
 
+MAINTENANCE_MODE = False
+MAINTENANCE_MODE_STATE_FILE_PATH = "/app/fm_eventmanager/maintenance_mode_state.txt"
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
 MAINTENANCE_MODE_IGNORE_URLS = ("^/u2f/",)
 


### PR DESCRIPTION
especially problematic in docker (there is no text editor of any kind in our container, no not even `ed`) this will expose the maintenance mode switch to be able to be toggled via environment variables