### PR TITLE
small verbiage fixes

### DIFF
--- a/registration/templates/registration/emails/staff/new.html
+++ b/registration/templates/registration/emails/staff/new.html
@@ -1,6 +1,6 @@
 {% load site %}
 <h3>Welcome to {{event.name}} staff!</h3>
 <p>If you have already registered as an attendee, do not use this form. Please contact staff services to get the correct registration link.</p>
-<p>Use this link to register as staff: <a href='https://{% current_domain %}{% url 'registration:new_staff' guid=registrationToken %}'>https://https://{% current_domain %}{% url 'registration:staff' guid=registrationToken %}</a></p>
+<p>Use this link to register as staff: <a href='https://{% current_domain %}{% url 'registration:new_staff' guid=registrationToken %}'>https://{% current_domain %}{% url 'registration:staff' guid=registrationToken %}</a></p>
 <p>&nbsp;</p>
 <p>Signature</p>

--- a/registration/templates/registration/onsite.html
+++ b/registration/templates/registration/onsite.html
@@ -80,9 +80,9 @@
           <div>
             <label>
               <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control-checkbox" required>
-              I agree to abide by {{ event }}'s <a href="{{ event.codeOfConduct }}">Code of Conduct</a>. By registering
-              for Mid-Atlantic Anthropomorphic Association’s {{ event }} you attest that you are not listed on any
-              sexual offender registry.
+              I agree to abide by the {{ event.name }} <a href="{{ event.codeOfConduct }}" target="_blank">Code of
+              Conduct</a>. By registering for {{ event }} you attest that you are not listed on any sexual offender
+              registry.
             </label>
           </div>
           <div class="col-sm-offset-3 help-block with-errors" style=" padding-left:15px;"></div>

--- a/registration/templates/registration/staff/staff-new-payment.html
+++ b/registration/templates/registration/staff/staff-new-payment.html
@@ -50,7 +50,9 @@
             <div class="col-sm-12">
               <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control form-control-checkbox"
                      required/>
-              I agree to abide by {{ event }}'s <a href="{{ event.codeOfConduct }}">Code of Conduct.</a>
+              I agree to abide by the {{ event.name }} <a href="{{ event.codeOfConduct }}" target="_blank">Code of
+              Conduct</a>. By registering for {{ event }} you attest that you are not listed on any sexual offender
+              registry.
             </div>
             <div class="col-sm-offset-1 help-block with-errors" style="padding-left:15px;"></div>
           </div>


### PR DESCRIPTION
unifying agreement message, fixing double https:// in email template, etc