### PR TITLE
Add dispute webhook information handling

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -984,14 +984,14 @@ print_badges.short_description = "Print Badges"
 
 
 def get_badge_type(badge):
-    #check if staff
+    # check if staff
     try:
         staff = Staff.objects.get(attendee=badge.attendee, event=badge.event)
     except Staff.DoesNotExist:
         pass
     else:
         return "Staff"
-    #check if dealer
+    # check if dealer
     try:
         dealers = Dealer.objects.get(attendee=badge.attendee, event=badge.event)
     except Dealer.DoesNotExist:
@@ -1332,6 +1332,9 @@ class OrderAdmin(ImportExportModelAdmin, NestedModelAdmin):
                 logger.warning(
                     f"Error while loading JSON from api_data for order {obj}"
                 )
+            else:
+                if "dispute" in obj.apiData:
+                    messages.warning("This transaction has been disputed")
 
         return super(OrderAdmin, self).render_change_form(
             request, context, *args, **kwargs

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -1330,7 +1330,8 @@ class OrderAdmin(ImportExportModelAdmin, NestedModelAdmin):
                     f"Error while loading JSON from apiData field for this order: {obj}",
                 )
                 logger.warning(
-                    f"Error while loading JSON from api_data for order {obj}"
+                    request,
+                    f"Error while loading JSON from api_data for order {obj}",
                 )
             else:
                 if "dispute" in obj.apiData:

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -1330,12 +1330,11 @@ class OrderAdmin(ImportExportModelAdmin, NestedModelAdmin):
                     f"Error while loading JSON from apiData field for this order: {obj}",
                 )
                 logger.warning(
-                    request,
                     f"Error while loading JSON from api_data for order {obj}",
                 )
             else:
                 if "dispute" in obj.apiData:
-                    messages.warning("This transaction has been disputed")
+                    messages.warning(request, "This transaction has been disputed")
 
         return super(OrderAdmin, self).render_change_form(
             request, context, *args, **kwargs

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -1334,7 +1334,9 @@ class OrderAdmin(ImportExportModelAdmin, NestedModelAdmin):
                 )
             else:
                 if "dispute" in obj.apiData:
-                    messages.warning(request, "This transaction has been disputed")
+                    messages.warning(
+                        request, "This transaction has been disputed by the cardholder"
+                    )
 
         return super(OrderAdmin, self).render_change_form(
             request, context, *args, **kwargs

--- a/registration/models.py
+++ b/registration/models.py
@@ -22,6 +22,15 @@ class HoldType(LookupTable):
     pass
 
 
+def get_hold_type(hold_name) -> HoldType:
+    try:
+        dispute_hold = HoldType.objects.get(name=hold_name)
+    except HoldType.DoesNotExist:
+        dispute_hold = HoldType(name=hold_name)
+        dispute_hold.save()
+    return dispute_hold
+
+
 class ShirtSizes(LookupTable):
     class Meta:
         db_table = "registration_shirt_sizes"
@@ -685,6 +694,13 @@ class Order(models.Model):
     FAILED = "Failed"  # Card was rejected by online authorization
     REFUNDED = "Refunded"
     REFUND_PENDING = "Refund Pending"
+    DISPUTE_EVIDENCE_REQUIRED = (
+        "Dispute Evidence Required"  # Initial state of a dispute with evidence required
+    )
+    DISPUTE_PROCESSING = "Dispute Processing"  # Dispute evidence has been submitted and the bank is processing
+    DISPUTE_WON = "Dispute Won"  # The bank has completed processing the dispute and the seller has won
+    DISPUTE_LOST = "Dispute Lost"  # The bank has completed processing the dispute and the seller has lost
+    DISPUTE_ACCEPTED = "Dispute Accepted"  # The seller has accepted the dispute
     STATUS_CHOICES = (
         (PENDING, "Pending"),
         (CAPTURED, "Captured"),
@@ -692,7 +708,24 @@ class Order(models.Model):
         (REFUNDED, "Refunded"),
         (REFUND_PENDING, "Refund Pending"),
         (FAILED, "Failed"),
+        (DISPUTE_EVIDENCE_REQUIRED, "Dispute Evidence Required"),
+        (DISPUTE_PROCESSING, "Dispute Processing"),
+        (DISPUTE_WON, "Dispute Won"),
+        (DISPUTE_LOST, "Dispute Lost"),
+        (DISPUTE_ACCEPTED, "Dispute Accepted"),
     )
+    # Maps Square dispute status to above status choices
+    DISPUTE_STATUS_MAP = {
+        "EVIDENCE_REQUIRED": DISPUTE_EVIDENCE_REQUIRED,
+        "PROCESSING": DISPUTE_PROCESSING,
+        "WON": DISPUTE_WON,
+        "LOST": DISPUTE_LOST,
+        "ACCEPTED": DISPUTE_ACCEPTED,
+        # Not certain what these states are for?
+        "INQUIRY_EVIDENCE_REQUIRED": DISPUTE_EVIDENCE_REQUIRED,
+        "INQUIRY_PROCESSING": DISPUTE_PROCESSING,
+        "INQUIRY_CLOSED": DISPUTE_WON,
+    }
     total = models.DecimalField(max_digits=8, decimal_places=2)
     status = models.CharField(max_length=50, choices=STATUS_CHOICES, default=PENDING)
     reference = models.CharField(max_length=50)

--- a/registration/payments.py
+++ b/registration/payments.py
@@ -392,10 +392,10 @@ def process_webhook_refund_update(notification) -> bool:
 def process_webhook_payment_updated(notification: PaymentWebhookNotification) -> bool:
     payment_id = notification.body["data"]["id"]
     try:
-        order = Order.objects.get(apiData__payment={"id": payment_id})
+        order = Order.objects.get(apiData__payment__id=payment_id)
     except Order.DoesNotExist:
         logger.warning(
-            f"Got refund.updated webhook update for a payment id not found: {payment_id}"
+            f"Got payment.updated webhook update for a payment id not found: {payment_id}"
         )
         return False
 
@@ -413,7 +413,7 @@ def process_webhook_refund_created(notification: PaymentWebhookNotification) -> 
     webhook_refund = notification.body["data"]["object"]["refund"]
     payment_id = webhook_refund["payment_id"]
     try:
-        order = Order.objects.get(apiData__payment={"id": payment_id})
+        order = Order.objects.get(apiData__payment__id=payment_id)
     except Order.DoesNotExist:
         logger.warning(
             f"Got refund.created webhook update for a payment id not found: {payment_id}"

--- a/registration/payments.py
+++ b/registration/payments.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+from datetime import datetime
 
 from django.conf import settings
 from square.client import Client
@@ -488,8 +489,9 @@ def process_webhook_dispute_created_or_updated(
                 firstName=attendee.firstName,
                 lastName=attendee.lastName,
                 email=attendee.email,
-                reason="Chargeback",
+                reason=f"Initiated chargeback [APIS {datetime.now().isoformat()}]",
             )
+
             ban.save()
 
     return True

--- a/registration/payments.py
+++ b/registration/payments.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from django.conf import settings
 from square.client import Client
 
+from . import emails
 from .models import *
 
 client = Client(
@@ -493,5 +494,8 @@ def process_webhook_dispute_created_or_updated(
             )
 
             ban.save()
+
+            # Send an email about it
+            emails.send_chargeback_notice_email(order)
 
     return True

--- a/registration/templates/registration/dealer/dealer-form.html
+++ b/registration/templates/registration/dealer/dealer-form.html
@@ -206,11 +206,11 @@
           </div>
         </div>
         <hr/>
-        <div>
-          <div>
+        <div class="form-group">
+            <div class="checkbox col-sm-12">
             <label>
               <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control-checkbox"
-                     required>
+                     required data-error="You must agree to the event code of conduct to register.">
               I have read and understand the rules pertaining to both {{ event.name }} and the Markeplace. I agree to
               abide by the {{ event.name }} <a href="{{ event.codeOfConduct }}" target="_blank">Code of Conduct</a>. By
               registering for {{ event }} you attest that you are not listed on any sexual offender registry.

--- a/registration/templates/registration/emails/chargeback-notice.html
+++ b/registration/templates/registration/emails/chargeback-notice.html
@@ -1,0 +1,23 @@
+<p>Hello {{ order.firstName }} {{ order.lastName}},</p>
+
+<p>Our systems have detected a chargeback dispute initated in relation to your registration transaction.</p>
+
+<p>
+  Consistent with our refund policy as outlined by the attendee <a href="{{ event.codeOfConduct }}">code of conduct</a>,
+  your order has been placed on hold, and you will be unable to retrieve your badge or register for {{ event.name }}
+  again at least until the dispute is settled.
+  </p>
+
+<p>
+Chargeback disputes (denying a charge) made for the sole purpose of avoiding payment, made without sufficient cause,
+or that are made without first attempting to resolve the dispute directly may result in permanent revocation of
+membership privileges.
+</p>
+<p>
+Please contact {{ event.registrationEmail }} for any questions or assistance.
+</p>
+
+<p>
+--<br>
+{{ event.name }} <a href="mailto:{{ event.registrationEmail }}">{{ event.registrationEmail }}</a>
+</p>

--- a/registration/templates/registration/emails/chargeback-notice.html
+++ b/registration/templates/registration/emails/chargeback-notice.html
@@ -1,4 +1,4 @@
-<p>Hello {{ order.firstName }} {{ order.lastName}},</p>
+<p>Hello {{ order.billingName }},</p>
 
 <p>Our systems have detected a chargeback dispute initated in relation to your registration transaction.</p>
 

--- a/registration/templates/registration/emails/chargeback-notice.txt
+++ b/registration/templates/registration/emails/chargeback-notice.txt
@@ -1,4 +1,4 @@
-Hello {{ order.firstName }} {{ order.lastName}},
+Hello {{ order.billingName }},
 
 Our systems have detected a chargeback dispute initated in relation to your registration transaction.
 

--- a/registration/templates/registration/emails/chargeback-notice.txt
+++ b/registration/templates/registration/emails/chargeback-notice.txt
@@ -1,0 +1,17 @@
+Hello {{ order.firstName }} {{ order.lastName}},
+
+Our systems have detected a chargeback dispute initated in relation to your registration transaction.
+
+Consistent with our refund policy as outlined by the attendee code of conduct, your order has been placed on hold,
+and you will be unable to retrieve your badge or register for {{ event.name }} again at least until
+the dispute is settled.
+
+Chargeback disputes (denying a charge) made for the sole purpose of avoiding payment, made without sufficient cause,
+or that are made without first attempting to resolve the dispute directly may result in permanent revocation of
+membership privileges.
+
+Please contact {{ event.registrationEmail }} for any questions or assistance.
+
+--
+{{ event.name }} <{{ event.registrationEmail }}>
+{{ event.codeOfConduct }}

--- a/registration/templates/registration/onsite.html
+++ b/registration/templates/registration/onsite.html
@@ -76,10 +76,11 @@
         <div class="row" id="levelContainer"></div>
         <br/>
         <hr/>
-        <div>
-          <div>
+        <div class="form-group">
+            <div class="checkbox col-sm-12">
             <label>
-              <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control-checkbox" required>
+              <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control-checkbox" required
+                      data-error="You must agree to the event code of conduct to register.">
               I agree to abide by the {{ event.name }} <a href="{{ event.codeOfConduct }}" target="_blank">Code of
               Conduct</a>. By registering for {{ event }} you attest that you are not listed on any sexual offender
               registry.

--- a/registration/templates/registration/registration-form.html
+++ b/registration/templates/registration/registration-form.html
@@ -81,10 +81,11 @@
         </div>
         <br/>
         <hr/>
-        <div>
-          <div>
+        <div class="form-group">
+          <div class="checkbox col-sm-12">
             <label>
-              <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control-checkbox" required>
+              <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control form-control-checkbox"
+                     required data-error="You must agree to the code of conduct to register." />
               I agree to abide by the {{ event.name }} <a href="{{ event.codeOfConduct }}" target="_blank">Code of
               Conduct</a>. By registering for {{ event }} you attest that you are not listed on any sexual offender
               registry.

--- a/registration/templates/registration/staff/staff-new-payment.html
+++ b/registration/templates/registration/staff/staff-new-payment.html
@@ -47,9 +47,9 @@
           <hr/>
 
           <div class="form-group">
-            <div class="col-sm-12">
+            <div class="checkbox col-sm-12">
               <input type="checkbox" id="agreeToRules" name="agreeToRules" class="form-control form-control-checkbox"
-                     required/>
+                     required data-error="You must agree to the event code of conduct to register.">
               I agree to abide by the {{ event.name }} <a href="{{ event.codeOfConduct }}" target="_blank">Code of
               Conduct</a>. By registering for {{ event }} you attest that you are not listed on any sexual offender
               registry.

--- a/registration/tests/test_emails.py
+++ b/registration/tests/test_emails.py
@@ -186,3 +186,17 @@ class TestDealerEmails(EmailTestCase):
         self.assertIn(self.assistant.registrationToken, html_text)
         self.assistant.refresh_from_db()
         self.assertTrue(self.assistant.sent)
+
+
+class TestChargebackEmail(EmailTestCase):
+    @patch("registration.emails.send_email")
+    def test_send_chargeback_notice_email(self, mock_send_email):
+        order = Order(
+            total="88.04",
+            status=Order.COMPLETED,
+            reference="FOOBAR",
+            billingEmail="apis@mailinator.com",
+            lastFour="1111",
+        )
+        emails.send_chargeback_notice_email(order)
+        mock_send_email.assert_called_once()

--- a/registration/tests/test_model.py
+++ b/registration/tests/test_model.py
@@ -2,7 +2,13 @@ from decimal import Decimal
 
 from django.test import TestCase
 
-from registration.models import Attendee, Charity, Venue
+from registration.models import (
+    Attendee,
+    Charity,
+    HoldType,
+    Venue,
+    get_hold_type,
+)
 from registration.tests.common import DEFAULT_VENUE_ARGS, TEST_ATTENDEE_ARGS
 
 
@@ -41,3 +47,18 @@ class TestAttendee(TestCase):
         preferredName = "Someone else"
         self.attendee.preferredName = preferredName
         self.assertEqual(self.attendee.getFirst(), preferredName)
+
+
+class TestHoldType(TestCase):
+    def setUp(self):
+        self.existing_hold = HoldType(name="Existing Hold")
+        self.existing_hold.save()
+        self.existing_hold.refresh_from_db()
+
+    def test_get_hold_type_existing_hold(self):
+        hold = get_hold_type("Existing Hold")
+        self.assertEqual(self.existing_hold, hold)
+
+    def test_get_hold_type_new(self):
+        hold = get_hold_type("New Hold")
+        self.assertNotEqual(self.existing_hold, hold)

--- a/registration/tests/test_webhooks.py
+++ b/registration/tests/test_webhooks.py
@@ -1,12 +1,23 @@
+import json
+
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from mock import patch
 
-from registration.models import PaymentWebhookNotification
+from registration.models import (
+    Attendee,
+    Badge,
+    BanList,
+    Event,
+    Order,
+    OrderItem,
+    PaymentWebhookNotification,
+)
+from registration.tests.common import DEFAULT_EVENT_ARGS, TEST_ATTENDEE_ARGS
 
 
-class TestSquareWebhooks(TestCase):
+class TestSquareRefundWebhooks(TestCase):
     EVENT_ID = "9c7300fc-5b0d-3ffb-8cd0-c2987b21099c"
     WEBHOOK_BODY = """{"merchant_id":"PXRNP8VV5DSQH","type":"refund.updated",
     "event_id":"9c7300fc-5b0d-3ffb-8cd0-c2987b21099c","created_at":"2022-12-29T06:30:29.411Z",
@@ -107,3 +118,179 @@ class TestSquareWebhooks(TestCase):
         )
 
         self.assertTrue(response.status_code, 409)
+
+
+class TestSquareDisputeWebhookCreate(TestCase):
+    # It's possible to test this E2E against the disputes API sandbox by setting particular payment values
+    # https://developer.squareup.com/docs/disputes-api/sandbox-testing
+    EVENT_ID = "936b73e0-5827-3a6f-a162-427b04a89d43"
+    PAYMENT_BODY = {
+        "payment": {
+            "id": "HbuhSBp9yJpt9iapF0ukqVvkCDMZY",
+            "created_at": "2024-02-02T01:46:48.469Z",
+            "updated_at": "2024-02-02T01:46:48.774Z",
+            "amount_money": {"amount": 8804, "currency": "USD"},
+            "status": "COMPLETED",
+            "delay_duration": "PT168H",
+            "source_type": "CARD",
+            "card_details": {
+                "status": "CAPTURED",
+                "card": {
+                    "card_brand": "VISA",
+                    "last_4": "1111",
+                    "exp_month": 5,
+                    "exp_year": 2025,
+                    "fingerprint": "sq-1-DjCOZOf2iusD6RSZ3k7XEjS0rxZB24OMDtlav-NIIWmZazJHNYRRw8iK3DFQFSOfgA",
+                    "card_type": "CREDIT",
+                    "prepaid_type": "NOT_PREPAID",
+                    "bin": "411111",
+                },
+                "entry_method": "KEYED",
+                "cvv_status": "CVV_ACCEPTED",
+                "avs_status": "AVS_ACCEPTED",
+                "statement_description": "SQ *DEFAULT TEST ACCOUNT",
+                "card_payment_timeline": {
+                    "authorized_at": "2024-02-02T01:46:48.589Z",
+                    "captured_at": "2024-02-02T01:46:48.774Z",
+                },
+            },
+            "location_id": "MESD3N22DWR0F",
+            "order_id": "myU3LuxKN4de1sjezcKrStcAa0FZY",
+            "reference_id": "GJWENL",
+            "risk_evaluation": {
+                "created_at": "2024-02-02T01:46:48.589Z",
+                "risk_level": "NORMAL",
+            },
+            "billing_address": {
+                "address_line_1": "Sint reprehenderit",
+                "address_line_2": "Veritatis accusamus ",
+                "locality": "Nisi obcaecati et er",
+                "administrative_district_level_1": "",
+                "postal_code": "11111",
+                "country": "AZ",
+                "first_name": "Chancellor",
+                "last_name": "Austin",
+            },
+            "total_money": {"amount": 8804, "currency": "USD"},
+            "approved_money": {"amount": 8804, "currency": "USD"},
+            "receipt_number": "Hbuh",
+            "receipt_url": "https://squareupsandbox.com/receipt/preview/HbuhSBp9yJpt9iapF0ukqVvkCDMZY",
+            "delay_action": "CANCEL",
+            "delayed_until": "2024-02-09T01:46:48.469Z",
+            "application_details": {
+                "square_product": "ECOMMERCE_API",
+                "application_id": "sandbox-sq0idb-GRQ64U8t_7bH0aJ51bQykw",
+            },
+            "version_token": "vSfY8mYPsyOVaNPqtPXomLQkZnqpkOx3yol16moTfGV6o",
+        }
+    }
+    WEBHOOK_BODY = json.loads(
+        """{
+      "merchant_id": "PXRNP8VV5DSQH",
+      "location_id": "MESD3N22DWR0F",
+      "type": "dispute.created",
+      "event_id": "936b73e0-5827-3a6f-a162-427b04a89d43",
+      "created_at": "2024-02-02T01:46:52.549Z",
+      "data": {
+        "type": "dispute",
+        "id": "7uVMgYjRu0KNYP1Dx8GRlD",
+        "object": {
+          "dispute": {
+            "amount_money": {
+              "amount": 8804,
+              "currency": "USD"
+            },
+            "brand_dispute_id": "iS7RtlifSQiWt1WQ2npk9Q",
+            "card_brand": "VISA",
+            "created_at": "2024-02-02T01:46:52.549Z",
+            "disputed_payment": {
+              "payment_id": "HbuhSBp9yJpt9iapF0ukqVvkCDMZY"
+            },
+            "due_at": "2024-02-16T00:00:00.000Z",
+            "id": "7uVMgYjRu0KNYP1Dx8GRlD",
+            "location_id": "MESD3N22DWR0F",
+            "reason": "NO_KNOWLEDGE",
+            "reported_at": "2024-02-02T00:00:00.000Z",
+            "state": "EVIDENCE_REQUIRED",
+            "updated_at": "2024-02-02T01:46:52.549Z"
+          }
+        }
+      }
+    }"""
+    )
+    SHA256_SIGNATURE = "thkLhRk6xWbmuN0N0alo56Dcl1U="
+    SIGNATURE_KEY = "Op83IrwJoz1do9FKFYE71g"
+    NOTIFICATION_URL = "https://webhook.site/4834cace-d117-4214-af36-5e8df062133d"
+
+    def setUp(self) -> None:
+        self.event = Event(**DEFAULT_EVENT_ARGS)
+        self.event.save()
+        self.order = Order(
+            total="88.04",
+            status=Order.COMPLETED,
+            reference="FOOBAR",
+            billingEmail="apis@mailinator.com",
+            lastFour="1111",
+            apiData=self.PAYMENT_BODY,
+        )
+        self.order.save()
+        self.attendee = Attendee(**TEST_ATTENDEE_ARGS)
+        self.attendee.save()
+        self.badge = Badge(
+            attendee=self.attendee, event=self.event, badgeName="Banned 4 Lyfe"
+        )
+        self.badge.save()
+        self.order_item = OrderItem(
+            order=self.order, badge=self.badge, enteredBy="Test"
+        )
+        self.order_item.save()
+        self.order.refresh_from_db()
+
+    @override_settings(SQUARE_WEBHOOK_SIGNATURE_KEY=SIGNATURE_KEY)
+    @patch("django.http.request.HttpRequest.build_absolute_uri")
+    def test_dispute_webhook(self, mock_build_absolute_uri):
+        mock_build_absolute_uri.return_value = self.NOTIFICATION_URL
+
+        response = self.client.post(
+            reverse("registration:square_webhook"),
+            self.WEBHOOK_BODY,
+            content_type="application/json",
+            HTTP_X_SQUARE_HMACSHA256_SIGNATURE=self.SHA256_SIGNATURE,
+        )
+
+        self.assertTrue(response.status_code, 200)
+        webhook = PaymentWebhookNotification.objects.get(event_id=self.EVENT_ID)
+        self.assertEqual(str(webhook.event_id), webhook.body["event_id"])
+        self.assertEqual(webhook.event_type, webhook.body["type"])
+
+        # Test that API data of the existing order has expected new content from the webhook:
+        self.order.refresh_from_db()
+        self.assertEqual(
+            self.order.apiData["dispute"],
+            self.WEBHOOK_BODY["data"]["object"]["dispute"],
+        )
+
+        self.order.refresh_from_db()
+        ban_list = BanList.objects.filter(email=self.attendee.email).first()
+        self.assertEqual(self.attendee.firstName, ban_list.firstName)
+        self.assertEqual(self.attendee.lastName, ban_list.lastName)
+
+    @override_settings(SQUARE_WEBHOOK_SIGNATURE_KEY=SIGNATURE_KEY)
+    @patch("django.http.request.HttpRequest.build_absolute_uri")
+    def test_dispute_payment_id_not_found(self, mock_build_absolute_uri):
+        self.order.apiData = {}
+        self.order.save()
+        self.order.refresh_from_db()
+
+        mock_build_absolute_uri.return_value = self.NOTIFICATION_URL
+
+        response = self.client.post(
+            reverse("registration:square_webhook"),
+            self.WEBHOOK_BODY,
+            content_type="application/json",
+            HTTP_X_SQUARE_HMACSHA256_SIGNATURE=self.SHA256_SIGNATURE,
+        )
+
+        self.assertTrue(response.status_code, 200)
+        webhook = PaymentWebhookNotification.objects.get(event_id=self.EVENT_ID)
+        self.assertFalse(webhook.processed)

--- a/registration/views/webhooks.py
+++ b/registration/views/webhooks.py
@@ -44,7 +44,10 @@ def square_webhook(request):
 
     # Store the verified event notification
     notification = PaymentWebhookNotification(
-        event_id=event_id, event_type=event_type, body=request_body, headers=dict(request.headers)
+        event_id=event_id,
+        event_type=event_type,
+        body=request_body,
+        headers=dict(request.headers),
     )
     try:
         process_webhook(notification)
@@ -62,6 +65,8 @@ def process_webhook(notification):
         result = payments.process_webhook_refund_created(notification)
     elif notification.body["type"] == "payment.updated":
         result = payments.process_webhook_payment_updated(notification)
+    elif notification.body["type"] in ("dispute.created", "dispute.updated"):
+        result = payments.process_webhook_dispute_created_or_updated(notification)
 
     notification.processed = result
     notification.save()

--- a/templates/admin/registration/order/change_form.html
+++ b/templates/admin/registration/order/change_form.html
@@ -2,9 +2,11 @@
 {% load i18n admin_urls %}
 {% block object-tools-items %}
     {% if perms.registration.issue_refund %}
-<li xmlns:admin="http://www.w3.org/1999/xhtml">
+      {% if not api_data.dispute %}
+    <li xmlns:admin="http://www.w3.org/1999/xhtml">
         <a href="{% url "admin:order_refund" original.pk %}" class="historylink">Refund</a>
     </li>
+      {% endif %}
     {% endif %}
     {% if api_data.payment.receipt_url %}
         <li>

--- a/templates/admin/registration/order/change_form.html
+++ b/templates/admin/registration/order/change_form.html
@@ -56,6 +56,19 @@
                 <strong>Refund ID:</strong> {{ refund.id }}<br>
 
             {% endfor %}
+
+            {%  if api_data.dispute %}
+                <br><hr>
+                <h3 style="color: orange">${{ api_data.dispute.amount_money.amount|slugify|slice:":-2" }}.{{ api_data.dispute.amount_money.amount|slugify|slice:"-2:" }}
+                {{  api_data.dispute.amount_money.currency }}
+                  Disputed {{  api_data.dispute.state }}</h3>
+                <strong>Reason:</strong> {{ api_data.dispute.reason }}<br>
+                <strong>Created:</strong> {{ api_data.dispute.created_at }}<br>
+                <strong>Updated:</strong> {{ api_data.dispute.updated_at }}<br>
+                <strong>Reported:</strong> {{ api_data.dispute.reported_at }}<br>
+                <strong>Due at:</strong> {{ api_data.dispute.due_at }}<br>
+
+            {%  endif %}
             </p>
         </div>
     </fieldset>


### PR DESCRIPTION
* Stores and updates orders with a disputed payment via webhook (enable webhook event types: `dispute.created`, `dispute.updated`
* Adds associated attendees of that order to the ban list
* Adds a banner in Order admin notating the dispute