### PR TITLE
Spruce up jquery load errors, allow adults to select address

### DIFF
--- a/registration/static/js/main.js
+++ b/registration/static/js/main.js
@@ -60,7 +60,7 @@ async function postJSON(url, body) {
     })
 }
 
-$("body").ready(function (e) {
+$(document).ready(function (e) {
     $.ajaxSetup({
         beforeSend: function(xhr, settings) {
             if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {

--- a/registration/static/js/upgrade.js
+++ b/registration/static/js/upgrade.js
@@ -1,9 +1,7 @@
-$("body").ready(function () {
+$(document).ready(function () {
     $("#cancel").click(function (e) {
           $.getJSON(URL_REGISTRATION_FLUSH, function (data) {
               window.location.reload();
           });
     });
-
-
 });

--- a/registration/templates/registration/attendee-locate.html
+++ b/registration/templates/registration/attendee-locate.html
@@ -57,7 +57,9 @@
 
   <script type="text/javascript">
 
-      $("#lookup").click(doRegister);
+      $(document).ready(function () {
+          $("#lookup").click(doRegister);
+      });
 
       function doRegister() {
           $("form").validator('validate');

--- a/registration/templates/registration/attendee-upgrade.html
+++ b/registration/templates/registration/attendee-upgrade.html
@@ -160,58 +160,61 @@
       var levelTemplateData = [];
       var shirtSizes = [];
 
-      $("body").ready(function () {
-          $.getJSON("{% url 'registration:pricelevels' %}", function (data) {
-              levelData = data;
-              var prevLevel = 50;
-              if (currentLevel && currentLevel.hasOwnProperty("basePrice")) {
-                  prevLevel = parseFloat(currentLevel.basePrice);
-              }
-              $.each(data, function (key, val) {
-                  let currentPrice = val.base_price - prevLevel;
-                  if (currentPrice > 0) {
-                      levelTemplateData.push({
-                          name: val.name,
-                          price: "$" + currentPrice,
-                          levelId: "level_" + val.id,
-                      });
+      $(document).ready(function () {
+          $("body").ready(function () {
+              $.getJSON("{% url 'registration:pricelevels' %}", function (data) {
+                  levelData = data;
+                  var prevLevel = 50;
+                  if (currentLevel && currentLevel.hasOwnProperty("basePrice")) {
+                      prevLevel = parseFloat(currentLevel.basePrice);
+                  }
+                  $.each(data, function (key, val) {
+                      let currentPrice = val.base_price - prevLevel;
+                      if (currentPrice > 0) {
+                          levelTemplateData.push({
+                              name: val.name,
+                              price: "$" + currentPrice,
+                              levelId: "level_" + val.id,
+                          });
+                      }
+                  });
+                  $("#levelContainer").loadTemplate($("#levelTemplate"), levelTemplateData);
+                  $(".changeLevel").hide();
+                  if (shirtSizes.length > 0) {
+                      $(".selectLevel")[0].click();
+                  }
+
+              });
+              $.getJSON("{% url 'registration:shirtsizes' %}", function (data) {
+                  shirtSizes = data;
+                  if (levelTemplateData.length > 0) {
+                      $(".selectLevel")[0].click();
                   }
               });
+          });
+
+          $("#levelContainer").on('click', 'a.selectLevel', function () {
+              clearLevels();
+              var levelId = $(this).attr('id').split('_')[1];
+              $.each(levelTemplateData, function (key, val) {
+                  var id = val.levelId.split('_')[1];
+                  if (id == levelId) {
+                      $("#regLevel").val(val.name);
+                      $("#levelContainer").loadTemplate($("#levelTemplate"), val);
+                      $(".changeLevel").show();
+                      $(".selectLevel").text("Selected!");
+                      generateOptions(id);
+                      return false;
+                  }
+              });
+          });
+          $("#levelContainer").on('click', 'a.changeLevel', function () {
               $("#levelContainer").loadTemplate($("#levelTemplate"), levelTemplateData);
+              $("#regLevel").val("");
               $(".changeLevel").hide();
-              if (shirtSizes.length > 0) {
-                  $(".selectLevel")[0].click();
-              }
-
-          });
-          $.getJSON("{% url 'registration:shirtsizes' %}", function (data) {
-              shirtSizes = data;
-              if (levelTemplateData.length > 0) {
-                  $(".selectLevel")[0].click();
-              }
           });
       });
 
-      $("#levelContainer").on('click', 'a.selectLevel', function () {
-          clearLevels();
-          var levelId = $(this).attr('id').split('_')[1];
-          $.each(levelTemplateData, function (key, val) {
-              var id = val.levelId.split('_')[1];
-              if (id == levelId) {
-                  $("#regLevel").val(val.name);
-                  $("#levelContainer").loadTemplate($("#levelTemplate"), val);
-                  $(".changeLevel").show();
-                  $(".selectLevel").text("Selected!");
-                  generateOptions(id);
-                  return false;
-              }
-          });
-      });
-      $("#levelContainer").on('click', 'a.changeLevel', function () {
-          $("#levelContainer").loadTemplate($("#levelTemplate"), levelTemplateData);
-          $("#regLevel").val("");
-          $(".changeLevel").hide();
-      });
       var clearLevels = function () {
           $.each(levelTemplateData, function (key, val) {
               $("#" + val.levelId).text("Select " + val.name);

--- a/registration/templates/registration/checkout.html
+++ b/registration/templates/registration/checkout.html
@@ -164,18 +164,20 @@
             {% if event.collectBillingAddress %}
               <h3>Billing Information</h3>
 
-              {% if not hasMinors and event.collectAddress %}
+              {% if event.collectAddress %}
                 <div class="form-group">
                   <label for="useFrom" class="col-sm-3 control-label">Use Billing Info From</label>
                   <div class="col-sm-9">
                     <select id="useFrom" class="form-control">
                       <option value="" selected>The Fields Below</option>
                       {% for oi in orderItems %}
+                        {% if not oi.attendee.isMinor %}
                         {% if oi.attendee %}
                           <option
                               value="{{ forloop.counter0 }}">{% attendee_get_first oi.attendee %} {{ oi.attendee.lastName }}</option>
                         {% else %}
                           <option value="{{ forloop.counter0 }}">{{ oi.badge.attendee }}</option>
+                        {% endif %}
                         {% endif %}
                       {% endfor %}
                     </select>
@@ -359,81 +361,79 @@
     </script>
   {% endif %}
   <script type="text/javascript">
+      $(document).ready(function () {
+         //$("#donateCharity").change(setTwoNumberDecimal);
+        //$("#donateOrg").change(setTwoNumberDecimal);
 
+        $(".deleteAttendee").click(function (e) {
+            const id = this.id.split('_')[1];
+            const data = {'id': id};
+            $.ajax({
+                "type": "POST",
+                "dataType": "json",
+                "url": URL_REGISTRATION_REMOVE_FROM_CART,
+                "data": JSON.stringify(data),
+                "beforeSend": function (xhr, settings) {
+                    console.log("Before Send");
+                    $.ajaxSettings.beforeSend(xhr, settings);
+                },
+                "error": function (result, status, error) {
+                    alert(`An error has occurred. If this error continues, please contact ${EVENT_REGISTRATION_EMAIL} for assistance.`);
+                },
+                "success": function (result, status) {
+                    if (result.success) {
+                        window.location.reload();
+                    } else {
+                        alert(`An error has occurred: ${result.message}. If this error continues, please contact ${EVENT_REGISTRATION_EMAIL} for assistance.`);
+                    }
+                }
+            });
+        });
 
-      //$("#donateCharity").change(setTwoNumberDecimal);
-      //$("#donateOrg").change(setTwoNumberDecimal);
+        $("#addAnother").click(function () {
+            window.location = URL_REGISTRATION_INDEX;
+        });
 
-      $(".deleteAttendee").click(function (e) {
-          const id = this.id.split('_')[1];
-          const data = {'id': id};
-          $.ajax({
-              "type": "POST",
-              "dataType": "json",
-              "url": URL_REGISTRATION_REMOVE_FROM_CART,
-              "data": JSON.stringify(data),
-              "beforeSend": function (xhr, settings) {
-                  console.log("Before Send");
-                  $.ajaxSettings.beforeSend(xhr, settings);
-              },
-              "error": function (result, status, error) {
-                  alert(`An error has occurred. If this error continues, please contact ${EVENT_REGISTRATION_EMAIL} for assistance.`);
-              },
-              "success": function (result, status) {
-                  if (result.success) {
-                      window.location.reload();
-                  } else {
-                      alert(`An error has occurred: ${result.message}. If this error continues, please contact ${EVENT_REGISTRATION_EMAIL} for assistance.`);
-                  }
-              }
-          });
+        $("#cancel").click(function () {
+            const cancel = window.confirm("Are you sure you want to cancel your registration? This will remove all attendees from your order.");
+            if (cancel == false) {
+                return;
+            }
+
+            $.getJSON(URL_REGISTRATION_CANCEL_ORDER, function (data) {
+                window.location = URL_REGISTRATION_INDEX;
+            });
+        });
+
+        $("#apply_discount").click(function (e) {
+            const discount = $("#discount").val();
+            if (discount == '') {
+                alert("You must enter a discount to apply.");
+                return;
+            }
+            const data = {'discount': discount};
+            $.ajax({
+                "type": "POST",
+                "dataType": "json",
+                "url": URL_REGISTRATION_DISCOUNT,
+                "data": JSON.stringify(data),
+                "beforeSend": function (xhr, settings) {
+                    console.log("Before Send");
+                    $.ajaxSettings.beforeSend(xhr, settings);
+                },
+                "error": function (result, status, error) {
+                    alert(`An error has occurred. If this error continues, please contact ${EVENT_REGISTRATION_EMAIL} for assistance.`);
+                },
+                "success": function (result, status) {
+                    if (result.success) {
+                        window.location.reload();
+                    } else {
+                        alert(`An error has occurred: ${result.message} If this error continues, please contact ` +
+                            `${EVENT_REGISTRATION_EMAIL} for assistance.`);
+                    }
+                }
+            });
+        });
       });
-
-      $("#addAnother").click(function () {
-          window.location = URL_REGISTRATION_INDEX;
-      });
-
-      $("#cancel").click(function () {
-          const cancel = window.confirm("Are you sure you want to cancel your registration? This will remove all attendees from your order.");
-          if (cancel == false) {
-              return;
-          }
-
-          $.getJSON(URL_REGISTRATION_CANCEL_ORDER, function (data) {
-              window.location = URL_REGISTRATION_INDEX;
-          });
-      });
-
-      $("#apply_discount").click(function (e) {
-          const discount = $("#discount").val();
-          if (discount == '') {
-              alert("You must enter a discount to apply.");
-              return;
-          }
-          const data = {'discount': discount};
-          $.ajax({
-              "type": "POST",
-              "dataType": "json",
-              "url": URL_REGISTRATION_DISCOUNT,
-              "data": JSON.stringify(data),
-              "beforeSend": function (xhr, settings) {
-                  console.log("Before Send");
-                  $.ajaxSettings.beforeSend(xhr, settings);
-              },
-              "error": function (result, status, error) {
-                  alert(`An error has occurred. If this error continues, please contact ${EVENT_REGISTRATION_EMAIL} for assistance.`);
-              },
-              "success": function (result, status) {
-                  if (result.success) {
-                      window.location.reload();
-                  } else {
-                      alert(`An error has occurred: ${result.message} If this error continues, please contact ` +
-                          `${EVENT_REGISTRATION_EMAIL} for assistance.`);
-                  }
-              }
-          });
-      });
-
-
   </script>
 {% endblock %}

--- a/registration/templates/registration/dealer/dealer-form.html
+++ b/registration/templates/registration/dealer/dealer-form.html
@@ -238,46 +238,6 @@
 
   <script type="text/javascript">
       var tableSizes = [];
-      $("body").ready(function () {
-          if (!Modernizr.inputtypes.date) {
-              $("#birthDate").datepicker({
-                  changeMonth: true,
-                  changeYear: true
-              });
-          }
-          $.getJSON("{% url 'registration:tablesizes' %}", function (data) {
-              tableSizes = data;
-              $.each(tableSizes, function (key, item) {
-                  $("#tableSize").append("<option value='" + item.id + "'>" + item.name + " ($" + item.basePrice + ")</option>");
-                  if (key == 0) {
-                      $("#tableSizeDescription").text(item.description);
-                      setTableInfo(item.id);
-                  }
-              });
-          });
-      });
-      $("#tableSize").on("change", function () {
-          var id = $(this).val();
-          $.each(tableSizes, function (key, item) {
-              if (item.id == id) {
-                  $("#tableSizeDescription").text(item.description);
-                  setTableInfo(id);
-              }
-          });
-      });
-
-      $("#next-personal").click(function () {
-          window.scrollTo(0, 0);
-      });
-
-      $("#next-optional").click(function () {
-          window.scrollTo(0, 0);
-      });
-
-      $(document).ready(function () {
-          $("form").fadeIn();
-      });
-
 
       function setTableInfo(id) {
           $.each(tableSizes, function (key, item) {
@@ -311,23 +271,6 @@
           });
       };
 
-      $("#country").on("change", function () {
-          if ($(this).val() == "US") {
-              $("#state").val("VA").removeAttr("disabled").attr("required", "required");
-              $("#zip").val("").removeAttr("disabled").attr("required", "required");
-          } else {
-              $("#state").val("").attr("disabled", "disabled").removeAttr("required");
-              $("#zip").val("").attr("disabled", "disabled").removeAttr("required");
-          }
-      });
-
-      $("#tempLicense").on("click", function () {
-          if ($(this).is(":checked")) {
-              $("#license").val("temporary").attr("disabled", "disabled");
-          } else {
-              $("#license").val("").removeAttr("disabled");
-          }
-      });
 
       function partnerLicense() {
           var id = this.id.split('_')[1];
@@ -338,9 +281,6 @@
           }
       }
 
-      $("#register1").click(doRegister);
-
-      $("#register").click(doRegister);
 
       function getPartners() {
           var partners = [];
@@ -370,6 +310,7 @@
           });
           return partners;
       }
+
 
       function doRegister() {
           $("form").validator('validate');
@@ -460,15 +401,79 @@
           return cookieValue;
       }
 
-      $.ajaxSetup({
-          beforeSend: function (xhr, settings) {
-              if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
-                  // Only send the token to relative URLs i.e. locally.
-                  xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+      $(document).ready(function () {
+          $.ajaxSetup({
+              beforeSend: function (xhr, settings) {
+                  if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
+                      // Only send the token to relative URLs i.e. locally.
+                      xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+                  }
               }
-          }
+          });
+
+          $("body").ready(function () {
+              if (!Modernizr.inputtypes.date) {
+                  $("#birthDate").datepicker({
+                      changeMonth: true,
+                      changeYear: true
+                  });
+              }
+              $.getJSON("{% url 'registration:tablesizes' %}", function (data) {
+                  tableSizes = data;
+                  $.each(tableSizes, function (key, item) {
+                      $("#tableSize").append("<option value='" + item.id + "'>" + item.name + " ($" + item.basePrice + ")</option>");
+                      if (key == 0) {
+                          $("#tableSizeDescription").text(item.description);
+                          setTableInfo(item.id);
+                      }
+                  });
+              });
+          });
+          $("#tableSize").on("change", function () {
+              var id = $(this).val();
+              $.each(tableSizes, function (key, item) {
+                  if (item.id == id) {
+                      $("#tableSizeDescription").text(item.description);
+                      setTableInfo(id);
+                  }
+              });
+          });
+
+          $("#next-personal").click(function () {
+              window.scrollTo(0, 0);
+          });
+
+          $("#next-optional").click(function () {
+              window.scrollTo(0, 0);
+          });
+
+          $("#country").on("change", function () {
+              if ($(this).val() == "US") {
+                  $("#state").val("VA").removeAttr("disabled").attr("required", "required");
+                  $("#zip").val("").removeAttr("disabled").attr("required", "required");
+              } else {
+                  $("#state").val("").attr("disabled", "disabled").removeAttr("required");
+                  $("#zip").val("").attr("disabled", "disabled").removeAttr("required");
+              }
+          });
+
+          $("#tempLicense").on("click", function () {
+              if ($(this).is(":checked")) {
+                  $("#license").val("temporary").attr("disabled", "disabled");
+              } else {
+                  $("#license").val("").removeAttr("disabled");
+              }
+          });
+
+          $("#register1").click(doRegister);
+
+          $("#register").click(doRegister);
+
       });
 
+      $(document).ready(function () {
+          $("form").fadeIn();
+      });
 
   </script>
 

--- a/registration/templates/registration/onsite-checkout.html
+++ b/registration/templates/registration/onsite-checkout.html
@@ -129,52 +129,6 @@
 
 {% block javascript %}
   <script type="text/javascript">
-      $("body").ready(function () {
-      });
-
-      $("#donateCharity").change(setTwoNumberDecimal);
-      $("#donateOrg").change(setTwoNumberDecimal);
-
-      $(".deleteAttendee").click(function (e) {
-          var id = this.id.split('_')[1];
-          var data = {'id': id}
-          $.ajax({
-              "type": "POST",
-              "dataType": "json",
-              "url": "{% url 'registration:remove_from_cart' %}",
-              "data": JSON.stringify(data),
-              "beforeSend": function (xhr, settings) {
-                  console.log("Before Send");
-                  $.ajaxSettings.beforeSend(xhr, settings);
-              },
-              "error": function (result, status, error) {
-                  alert(error);
-              },
-              "success": function (result, status) {
-                  if (result.success) {
-                      window.location.reload();
-                  } else {
-                      alert("An error has occurred: " + result.message + " If this error continues, please contact {{event.registrationEmail}} for assistance.");
-                  }
-              }
-          });
-      });
-
-      $("#addAnother").click(function () {
-          window.location = "{% url 'registration:onsite' %}";
-      });
-
-      $("#cancel").click(function () {
-          var cancel = window.confirm("Are you sure you want to cancel your registration? This will remove all attendees from your order.")
-          if (cancel == false) {
-              return;
-          }
-
-          $.getJSON("{% url 'registration:cancel_order' %}", function (data) {
-              window.location = "{% url 'registration:onsite' %}";
-          });
-      });
-
       function checkout_click(e) {
           e.preventDefault();
           $("form").validator('validate');
@@ -219,7 +173,52 @@
 
       }
 
-      $("#checkout").one('click', checkout_click);
+
+      $(document).ready(function () {
+          $("#donateCharity").change(setTwoNumberDecimal);
+          $("#donateOrg").change(setTwoNumberDecimal);
+          $("#checkout").one('click', checkout_click);
+
+          $(".deleteAttendee").click(function (e) {
+              var id = this.id.split('_')[1];
+              var data = {'id': id}
+              $.ajax({
+                  "type": "POST",
+                  "dataType": "json",
+                  "url": "{% url 'registration:remove_from_cart' %}",
+                  "data": JSON.stringify(data),
+                  "beforeSend": function (xhr, settings) {
+                      console.log("Before Send");
+                      $.ajaxSettings.beforeSend(xhr, settings);
+                  },
+                  "error": function (result, status, error) {
+                      alert(error);
+                  },
+                  "success": function (result, status) {
+                      if (result.success) {
+                          window.location.reload();
+                      } else {
+                          alert("An error has occurred: " + result.message + " If this error continues, please contact {{event.registrationEmail}} for assistance.");
+                      }
+                  }
+              });
+          });
+
+          $("#addAnother").click(function () {
+              window.location = "{% url 'registration:onsite' %}";
+          });
+
+          $("#cancel").click(function () {
+              var cancel = window.confirm("Are you sure you want to cancel your registration? This will remove all attendees from your order.")
+              if (cancel == false) {
+                  return;
+              }
+
+              $.getJSON("{% url 'registration:cancel_order' %}", function (data) {
+                  window.location = "{% url 'registration:onsite' %}";
+              });
+          });
+      });
 
   </script>
 {% endblock %}

--- a/registration/templates/registration/onsite.html
+++ b/registration/templates/registration/onsite.html
@@ -265,111 +265,113 @@
           });
       });
 
-      // scroll to top on all the next views
-      $("#next-personal").click(function () {
-          window.scrollTo(0, 0);
-      });
+      $(document).ready(function () {
+          // scroll to top on all the next views
+          $("#next-personal").click(function () {
+              window.scrollTo(0, 0);
+          });
 
-      $("#levelContainer").on('click', 'a.selectLevel', function () {
-          clearLevels();
-          var levelId = $(this).attr('id').split('_')[1];
-          $.each(levelTemplateData, function (key, val) {
-              var id = val.levelId.split('_')[1];
-              if (id == levelId) {
-                  $("#regLevel").val(val.name);
-                  $("#levelContainer").loadTemplate($("#levelTemplate"), val);
-                  $(".changeLevel").show();
-                  $(".selectLevel").text("Selected!");
-                  generateOptions(id);
+          $("#levelContainer").on('click', 'a.selectLevel', function () {
+              clearLevels();
+              var levelId = $(this).attr('id').split('_')[1];
+              $.each(levelTemplateData, function (key, val) {
+                  var id = val.levelId.split('_')[1];
+                  if (id == levelId) {
+                      $("#regLevel").val(val.name);
+                      $("#levelContainer").loadTemplate($("#levelTemplate"), val);
+                      $(".changeLevel").show();
+                      $(".selectLevel").text("Selected!");
+                      generateOptions(id);
+                      return false;
+                  }
+              });
+              $.each(minorLevelTemplateData, function (key, val) {
+                  var id = val.levelId.split('_')[1];
+                  if (id == levelId) {
+                      $("#regLevel").val(val.name);
+                      $("#levelContainer").loadTemplate($("#levelTemplate"), val);
+                      $(".changeLevel").show();
+                      $(".selectLevel").text("Selected!");
+                      generateOptions(id);
+                      return false;
+                  }
+              });
+              $.each(accompaniedLevelTemplateData, function (key, val) {
+                  var id = val.levelId.split('_')[1];
+                  if (id == levelId) {
+                      $("#regLevel").val(val.name);
+                      $("#levelContainer").loadTemplate($("#levelTemplate"), val);
+                      $(".changeLevel").show();
+                      $(".selectLevel").text("Selected!");
+                      generateOptions(id);
+                      return false;
+                  }
+              });
+              $.each(freeLevelTemplateData, function (key, val) {
+                  var id = val.levelId.split('_')[1];
+                  if (id == levelId) {
+                      $("#regLevel").val(val.name);
+                      $("#levelContainer").loadTemplate($("#levelTemplate"), val);
+                      $(".changeLevel").show();
+                      $(".selectLevel").text("Selected!");
+                      generateOptions(id);
+                      return false;
+                  }
+              });
+          });
+
+          $("body").on("click", '#next-personal', function () {
+              if (Modernizr.inputtypes.date) {
+                  // native datepicker - expect ISO date
+                  var birthdate = parseDate($("#birthDate").val());
+              } else {
+                  // American middle-endian format put out by datepicker javascript
+                  var birthdate = new Date(Date.parse($("#birthDate").val()));
+              }
+
+              try {
+                  var age = getAgeByEventStart(birthdate);
+              } catch (e) {
+                  console.log(e);
+                  alert(e);
+              }
+
+              var level_data = [];
+
+              if (age < 0) {
+                  alert("You must be born before today to exist.\n(Please check your date of birth and try again)");
                   return false;
               }
-          });
-          $.each(minorLevelTemplateData, function (key, val) {
-              var id = val.levelId.split('_')[1];
-              if (id == levelId) {
-                  $("#regLevel").val(val.name);
-                  $("#levelContainer").loadTemplate($("#levelTemplate"), val);
-                  $(".changeLevel").show();
-                  $(".selectLevel").text("Selected!");
-                  generateOptions(id);
+
+              if (age < 7) {
+                  level_data = freeLevelTemplateData
+
+              } else if (age < 13) {
+                  level_data = accompaniedLevelTemplateData;
+
+              } else if (age < 18) {
+                  level_data = minorLevelTemplateData;
+
+              } else {
+                  level_data = levelTemplateData;
+              }
+
+              if (level_data.length == 0) {
+                  alert("Assistance Required:\n\nNo price level matching this age range (age = " + age + ") is available for this event.  Please see staff for assistance.");
                   return false;
               }
+
+              $("#levelContainer").loadTemplate($("#levelTemplate"), level_data);
+              $(".changeLevel").hide();
+
           });
-          $.each(accompaniedLevelTemplateData, function (key, val) {
-              var id = val.levelId.split('_')[1];
-              if (id == levelId) {
-                  $("#regLevel").val(val.name);
-                  $("#levelContainer").loadTemplate($("#levelTemplate"), val);
-                  $(".changeLevel").show();
-                  $(".selectLevel").text("Selected!");
-                  generateOptions(id);
-                  return false;
-              }
+
+
+          $("#levelContainer").on('click', 'a.changeLevel', function () {
+              $("#levelContainer").loadTemplate($("#levelTemplate"), levelTemplateData);
+              $("#regLevel").val("");
+              $(".changeLevel").hide();
           });
-          $.each(freeLevelTemplateData, function (key, val) {
-              var id = val.levelId.split('_')[1];
-              if (id == levelId) {
-                  $("#regLevel").val(val.name);
-                  $("#levelContainer").loadTemplate($("#levelTemplate"), val);
-                  $(".changeLevel").show();
-                  $(".selectLevel").text("Selected!");
-                  generateOptions(id);
-                  return false;
-              }
-          });
-      });
-
-      $("body").on("click", '#next-personal', function () {
-          if (Modernizr.inputtypes.date) {
-              // native datepicker - expect ISO date
-              var birthdate = parseDate($("#birthDate").val());
-          } else {
-              // American middle-endian format put out by datepicker javascript
-              var birthdate = new Date(Date.parse($("#birthDate").val()));
-          }
-
-          try {
-              var age = getAgeByEventStart(birthdate);
-          } catch (e) {
-              console.log(e);
-              alert(e);
-          }
-
-          var level_data = [];
-
-          if (age < 0) {
-              alert("You must be born before today to exist.\n(Please check your date of birth and try again)");
-              return false;
-          }
-
-          if (age < 7) {
-              level_data = freeLevelTemplateData
-
-          } else if (age < 13) {
-              level_data = accompaniedLevelTemplateData;
-
-          } else if (age < 18) {
-              level_data = minorLevelTemplateData;
-
-          } else {
-              level_data = levelTemplateData;
-          }
-
-          if (level_data.length == 0) {
-              alert("Assistance Required:\n\nNo price level matching this age range (age = " + age + ") is available for this event.  Please see staff for assistance.");
-              return false;
-          }
-
-          $("#levelContainer").loadTemplate($("#levelTemplate"), level_data);
-          $(".changeLevel").hide();
-
-      });
-
-
-      $("#levelContainer").on('click', 'a.changeLevel', function () {
-          $("#levelContainer").loadTemplate($("#levelTemplate"), levelTemplateData);
-          $("#regLevel").val("");
-          $(".changeLevel").hide();
       });
 
       var clearLevels = function () {
@@ -546,7 +548,9 @@
           });
       }
 
-      $("#register").one('click', register_click);
+      $(document).ready(function () {
+          $("#register").one('click', register_click);
+      });
   </script>
 
   <script src="{% static 'js/date-entry.js' %}"></script>

--- a/registration/templates/registration/registration-form.html
+++ b/registration/templates/registration/registration-form.html
@@ -259,16 +259,18 @@
           });
       });
 
-      $("#levelContainer").on('click', 'a.selectLevel', function () {
-          clearLevels();
-          var levelId = $(this).attr('id').split('_')[1];
-          select_level(levelId);
-      });
+      $(document).ready(function () {
+          $("#levelContainer").on('click', 'a.selectLevel', function () {
+              clearLevels();
+              var levelId = $(this).attr('id').split('_')[1];
+              select_level(levelId);
+          });
 
-      $("#levelContainer").on('click', 'a.changeLevel', function () {
-          $("#levelContainer").loadTemplate($("#levelTemplate"), levelTemplateData);
-          $("#regLevel").val("");
-          $(".changeLevel").hide();
+          $("#levelContainer").on('click', 'a.changeLevel', function () {
+              $("#levelContainer").loadTemplate($("#levelTemplate"), levelTemplateData);
+              $("#regLevel").val("");
+              $(".changeLevel").hide();
+          });
       });
 
       var clearLevels = function () {
@@ -480,11 +482,10 @@
 
       $(document).ready(function (e) {
           $("#register").one('click', register_click);
-      });
 
-
-      $(document).on("click", ".open-image", function (event) {
-          window.open($(event.target).data("image"), "_blank", "width=750,height=750,left=35%,top=25%,menubar=no,statusbar=no");
+          $(document).on("click", ".open-image", function (event) {
+              window.open($(event.target).data("image"), "_blank", "width=750,height=750,left=35%,top=25%,menubar=no,statusbar=no");
+          });
       });
 
   </script>

--- a/registration/views/cart.py
+++ b/registration/views/cart.py
@@ -31,6 +31,7 @@ def get_cart(request):
         hasMinors = False
         for item in orderItems:
             if item.badge.isMinor():
+                item.isMinor = True
                 hasMinors = True
                 break
 
@@ -79,7 +80,9 @@ def get_cart(request):
                 - birthdate.year
                 - ((evt.month, evt.day) < (birthdate.month, birthdate.day))
             )
+            pda["isMinor"] = False
             if age_at_event < 18:
+                pda["isMinor"] = True
                 hasMinors = True
 
             pdp = cartJson["priceLevel"]


### PR DESCRIPTION
The "Use billing info from" field was previously hidden if there were any minors in the cart, making more work for parents to fill out this form.  Reworked to simply omit minors from the selection choices.

Also reworked jquery initializations missing from a few places, should fix relevant glitchtips.  Have not extensively tested all pages yet.