### PR TITLE
Fix dispute updated event type

### DIFF
--- a/registration/views/webhooks.py
+++ b/registration/views/webhooks.py
@@ -65,7 +65,7 @@ def process_webhook(notification):
         result = payments.process_webhook_refund_created(notification)
     elif notification.body["type"] == "payment.updated":
         result = payments.process_webhook_payment_updated(notification)
-    elif notification.body["type"] in ("dispute.created", "dispute.updated"):
+    elif notification.body["type"] in ("dispute.created", "dispute.state.updated"):
         result = payments.process_webhook_dispute_created_or_updated(notification)
 
     notification.processed = result


### PR DESCRIPTION
The [disputes API webhook](https://developer.squareup.com/docs/webhooks/v2webhook-events-tech-ref) type for updates was incorrectly referenced here.