### PR TITLE
Fix debug flag parsing, enable debug toolbar in docker

### DIFF
--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -58,7 +58,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DJANGO_DEBUG', False)
+DEBUG = eval_bool(os.getenv('DJANGO_DEBUG', False))
 
 LOGGING = {
     'version': 1,

--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -322,9 +322,13 @@ LOGIN_REDIRECT_URL = 'u2f:two-factor-settings'
 LOGIN_URL = 'u2f:login'
 
 if DEBUG:
+    # Adds docker NAT routers and any internal upstream proxies as internal IPs to enable the debug toolbar
     import socket  # only if you haven't already imported this
-    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.0.4"]
+    INTERNAL_IPS = ["127.0.0.1"]
+    for proxy_host in (socket.gethostname(), os.getenv("INTERNAL_PROXY_HOST")):
+        if proxy_host:
+            hostname, _, ips = socket.gethostbyname_ex(proxy_host)
+            INTERNAL_IPS += [ip[: ip.rfind(".")] + ".1" for ip in ips] + ips
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/

--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -321,7 +321,10 @@ MAINTENANCE_MODE_IGNORE_URLS = ("^/u2f/",)
 LOGIN_REDIRECT_URL = 'u2f:two-factor-settings'
 LOGIN_URL = 'u2f:login'
 
-INTERNAL_IPS = ['127.0.0.1']
+if DEBUG:
+    import socket  # only if you haven't already imported this
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.0.4"]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/


### PR DESCRIPTION
Debug toolbar requires adding internal IPs to allow access, so I've added a flag to allow specifying the reverse-proxy host to be added to that list.