### PR TITLE
Fix for DJANGO_DEBUG env var unset

### DIFF
--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -58,7 +58,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = eval_bool(os.getenv('DJANGO_DEBUG', False))
+DEBUG = eval_bool(os.getenv('DJANGO_DEBUG', "False"))
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Woops.  That env var was commented out in production.