### PR TITLE
Add write-through database cache session, db conn persistence

### DIFF
--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -189,6 +189,10 @@ DATABASES = {
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+# Enable persistent database connections
+# https://docs.djangoproject.com/en/3.2/ref/databases/#persistent-database-connections
+CONN_MAX_AGE = os.getenv("DJANGO_CONN_MAX_AGE", 0)
+
 
 # Cache
 # https://docs.djangoproject.com/en/3.2/topics/cache/
@@ -199,7 +203,8 @@ CACHES = {
         "LOCATION": os.getenv("DJANGO_REDIS_URL", "redis://redis:6379/1"),
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        }
+        },
+        "KEY_PREFIX": os.getenv('DJANGO_REDIS_KEY_PREFIX', 'apis'),
     }
 }
 
@@ -339,6 +344,8 @@ STATIC_ROOT = '/app/apis/static/'
 # Session Management
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 60*60*24  # 24hr
+# Write-through cache session (redis cache, persisted to db).
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
 # Default email to display as part of error messages
 APIS_DEFAULT_EMAIL = os.getenv('APIS_DEFAULT_EMAIL', "registration@example.com")


### PR DESCRIPTION
Storing sessions in cache should improve performance for logged-in views (~120ms query hitting databatse).

Persisting the database connection for ~1 minute should improve overall performance, though using a connection pooler like pgbouncer and leaving that off might be a better option.