### PR TITLE
Fix U2F sub-dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/furthemore/apis:apis-base-3ba493b
+FROM ghcr.io/furthemore/apis:apis-base-11fb148
 
 LABEL org.opencontainers.image.source="https://github.com/furthemore/APIS"
 

--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -122,12 +122,12 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'widget_tweaks',
     'mathfilters',
-    'nested_inline',
     'import_export',
     'django_extensions',
     'django_u2f',
     'maintenance_mode',
     'registration',
+    'nested_inline',
     'debug_toolbar',
     'django_prometheus',
 ]

--- a/registration/tests/test_templates.py
+++ b/registration/tests/test_templates.py
@@ -1,0 +1,9 @@
+import unittest
+
+from django.core.management import call_command
+
+
+class TestTemplates(unittest.TestCase):
+    def test_validate_templates(self):
+        call_command("validate_templates")
+        # This throws an error if it fails to validate

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-nested-inline~=0.4.6
 django-prometheus~=2.3.1
 django-redis~=5.4.0
 #django-u2f~=1.0.1
-git+https://github.com/gavinwahl/django-u2f.git@34410af
+git+https://github.com/rechner/django-u2f.git@23022f8
 django-widget-tweaks==1.5.0
 freezegun==1.4.0
 influxdb~=5.3.1          # Influx < v1.7


### PR DESCRIPTION
The django-u2f dependency had a lose specification for webauthn, which pulled in some breaking changes.