### PR TITLE
clearer closed messages

### DIFF
--- a/registration/templates/registration/closed.html
+++ b/registration/templates/registration/closed.html
@@ -5,7 +5,7 @@
     <div role="tabpanel" class="tab-pane fade in active" id="personal">
       <h1>Registration - {{ event }}</h1>
       <hr>
-      <p>Registration for {{ event }} is closed. If you have any questions please contact
+      <p>Registration for {{ event }} {{ message }} If you have any questions please contact
         <a href="mailto:{{ event.registrationEmail }}">{{ event.registrationEmail }}</a>
       </p>
       <p style="float:right;">

--- a/registration/templates/registration/closed.html
+++ b/registration/templates/registration/closed.html
@@ -5,7 +5,8 @@
     <div role="tabpanel" class="tab-pane fade in active" id="personal">
       <h1>Registration - {{ event }}</h1>
       <hr>
-      <p>Registration for {{ event }} {{ message }} If you have any questions please contact
+      <p>Registration for {{ event }} {{ message }}</p>
+      <p>If you have any questions please contact
         <a href="mailto:{{ event.registrationEmail }}">{{ event.registrationEmail }}</a>
       </p>
       <p style="float:right;">

--- a/registration/templates/registration/dealer/dealer-closed.html
+++ b/registration/templates/registration/dealer/dealer-closed.html
@@ -5,7 +5,8 @@
     <div role="tabpanel" class="tab-pane fade in active" id="personal">
       <h1>Dealer Registration - {{ event }}</h1>
       <hr>
-      <p>Dealer registration for {{ event }} is closed. If you have any questions please contact
+      <p>Dealer registration for {{ event }} {{ message }}</p>
+      <p>If you have any questions please contact
         <a href='mailto:{{ event.dealerEmail }}'>{{ event.dealerEmail }}</a></p>
       <p style='float:right;'><a href='/'>Back to Main Page</a></p>
     </div>

--- a/registration/templates/registration/staff/staff-closed.html
+++ b/registration/templates/registration/staff/staff-closed.html
@@ -5,7 +5,8 @@
     <div role="tabpanel" class="tab-pane fade in active" id="personal">
       <h1>Staff Registration - {{ event }}</h1>
       <hr>
-      <p>Staff Registration for {{ event }} is closed. If you have any questions please contact
+      <p>Staff Registration for {{ event }} {{ message }}>/p>
+      <p>If you have any questions please contact
         <a href="mailto:{{ event.staffEmail }}">{{ event.staffEmail }}</a>
       </p>
       <p style="float:right;">

--- a/registration/tests/test_dealers.py
+++ b/registration/tests/test_dealers.py
@@ -1,6 +1,8 @@
 from django.http import HttpRequest
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
+from datetime import timedelta
 from freezegun import freeze_time
 
 from registration.models import Attendee, Dealer, DealerAsst, Event
@@ -53,11 +55,17 @@ class TestDealers(DealerTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(b"not yet open", response.content)
 
-    @freeze_time("2020-01-01")
-    def test_addNewDealer_closed(self) -> None:
+    @freeze_time(timezone.now() - timedelta(days=20))
+    def test_addNewDealer_closed_upcoming(self) -> None:
         response = self.client.get(reverse("registration:new_dealer"))
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"not yet open", response.content)
+
+    @freeze_time(timezone.now() + timedelta(days=20))
+    def test_addNewDealer_closed_ended(self) -> None:
+        response = self.client.get(reverse("registration:new_dealer"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"has ended", response.content)
 
     def test_find_dealer_to_add_assistant(self):
         response = self.client.get(

--- a/registration/tests/test_dealers.py
+++ b/registration/tests/test_dealers.py
@@ -51,13 +51,13 @@ class TestDealers(DealerTestCase):
     def test_addNewDealer_open(self) -> None:
         response = self.client.get(reverse("registration:new_dealer"))
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(b"closed", response.content)
+        self.assertNotIn(b"not yet open", response.content)
 
     @freeze_time("2020-01-01")
     def test_addNewDealer_closed(self) -> None:
         response = self.client.get(reverse("registration:new_dealer"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"closed", response.content)
+        self.assertIn(b"not yet open", response.content)
 
     def test_find_dealer_to_add_assistant(self):
         response = self.client.get(

--- a/registration/tests/test_index.py
+++ b/registration/tests/test_index.py
@@ -20,7 +20,12 @@ class Index(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Welcome to the registration system")
 
-    def TestIndexClosed(self):
+    def TestIndexClosedUpcoming(self):
+        response = self.client.get(reverse("registration:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "not yet open")
+
+    def TestIndexClosedEnded(self):
         response = self.client.get(reverse("registration:index"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "has ended")
@@ -36,9 +41,14 @@ class Index(TestCase):
         self.event = Event(**DEFAULT_EVENT_ARGS)
         self.event.save()
         self.TestIndex()
-        self.event.attendeeRegEnd = now - ten_days
+        self.event.attendeeRegStart = now + one_day
+        self.event.attendeeRegEnd = now + ten_days
         self.event.save()
-        self.TestIndexClosed()
+        self.TestIndexClosedUpcoming()
+        self.event.attendeeRegStart = now - ten_days
+        self.event.attendeeRegEnd = now - one_day
+        self.event.save()
+        self.TestIndexClosedEnded()
 
 
 class TestTemplateTags(TestCase):

--- a/registration/tests/test_index.py
+++ b/registration/tests/test_index.py
@@ -23,7 +23,7 @@ class Index(TestCase):
     def TestIndexClosed(self):
         response = self.client.get(reverse("registration:index"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "is closed. If you have any")
+        self.assertContains(response, "has ended")
 
     def TestIndexNoEvent(self):
         response = self.client.get(reverse("registration:index"))

--- a/registration/tests/test_onsite.py
+++ b/registration/tests/test_onsite.py
@@ -131,13 +131,21 @@ class TestOnsiteCart(OnsiteBaseTestCase):
         self.assertEqual(response.context["event"], self.event)
         self.assertIn(b"Onsite Registration", response.content)
 
-    def test_onsite_closed(self):
+    def test_onsite_closed_upcoming(self):
         self.event.onsiteRegStart = now + one_day
         self.event.save()
         response = self.client.get(reverse("registration:onsite"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["event"], self.event)
         self.assertIn(b"not yet open", response.content)
+
+    def test_onsite_closed_ended(self):
+        self.event.onsiteRegEnd = now - one_day
+        self.event.save()
+        response = self.client.get(reverse("registration:onsite"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["event"], self.event)
+        self.assertIn(b"has ended", response.content)
 
     def test_onsite_checkout_cost(self):
         options = [

--- a/registration/tests/test_onsite.py
+++ b/registration/tests/test_onsite.py
@@ -137,7 +137,7 @@ class TestOnsiteCart(OnsiteBaseTestCase):
         response = self.client.get(reverse("registration:onsite"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["event"], self.event)
-        self.assertIn(b"is closed", response.content)
+        self.assertIn(b"not yet open", response.content)
 
     def test_onsite_checkout_cost(self):
         options = [

--- a/registration/tests/test_staff.py
+++ b/registration/tests/test_staff.py
@@ -118,7 +118,7 @@ class TestNewStaff(StaffTestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(b"closed", response.content)
+        self.assertNotIn(b"not yet open", response.content)
 
     @freeze_time("2000-01-01")
     def test_new_staff_invite_good_closed(self):
@@ -132,7 +132,7 @@ class TestNewStaff(StaffTestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"closed", response.content)
+        self.assertIn(b"not yet open", response.content)
 
     @freeze_time("2000-01-01")
     def test_new_staff_invite_override(self):
@@ -146,7 +146,7 @@ class TestNewStaff(StaffTestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(b"closed", response.content)
+        self.assertNotIn(b"not yet open", response.content)
 
 
 class TestFindNewStaff(StaffTestCase):
@@ -270,13 +270,13 @@ class TestStaffIndex(StaffTestCase):
     def test_staff_index(self):
         response = self.client.get(reverse("registration:staff", args=("foo",)))
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(b"closed", response.content)
+        self.assertNotIn(b"not yet open", response.content)
         
     @freeze_time("2000-01-01")
     def test_staff_index_closed(self):
         response = self.client.get(reverse("registration:staff", args=("foo",)))
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"closed", response.content)
+        self.assertIn(b"not yet open", response.content)
 
     def test_staff_done(self):
         response = self.client.get(reverse("registration:staff_done"))

--- a/registration/views/common.py
+++ b/registration/views/common.py
@@ -216,7 +216,12 @@ def index(request):
     context = {"event": event, "discount": discount}
     if event.attendeeRegStart <= today <= event.attendeeRegEnd:
         return render(request, "registration/registration-form.html", context)
-    return render(request, "registration/closed.html", context)
+    elif event.attendeeRegStart >= today:
+        context["message"] = "is not yet open. Please stay tuned to our social media for updates!"
+        return render(request, "registration/closed.html", context)
+    elif event.attendeeRegEnd <= today:
+        context["message"] = "has ended."
+        return render(request, "registration/closed.html", context)
 
 
 @staff_member_required

--- a/registration/views/dealers.py
+++ b/registration/views/dealers.py
@@ -74,7 +74,12 @@ def new_dealer(request):
     context = {"event": event}
     if event.dealerRegStart <= today <= event.dealerRegEnd:
         return render(request, "registration/dealer/dealer-form.html", context)
-    return render(request, "registration/dealer/dealer-closed.html", context)
+    elif event.dealerRegStart >= today:
+        context["message"] = "is not yet open. Please stay tuned to our social media for updates!"
+        return render(request, "registration/dealer/dealer-closed.html", context)
+    elif event.dealerRegEnd <= today:
+        context["message"] = "has ended."
+        return render(request, "registration/dealer/dealer-closed.html", context)
 
 
 def info_dealer(request):

--- a/registration/views/onsite.py
+++ b/registration/views/onsite.py
@@ -27,7 +27,12 @@ def onsite(request):
     context = {"event": event, "onsite": True}
     if event.onsiteRegStart <= today <= event.onsiteRegEnd:
         return render(request, "registration/onsite.html", context)
-    return render(request, "registration/closed.html", context)
+    elif event.onsiteRegStart >= today:
+        context["message"] = "is not yet open. Please stay tuned to our social media for updates!"
+        return render(request, "registration/closed.html", context)
+    elif event.onsiteRegEnd <= today:
+        context["message"] = "has ended."
+        return render(request, "registration/closed.html", context)
 
 
 def onsite_cart(request):

--- a/registration/views/staff.py
+++ b/registration/views/staff.py
@@ -33,7 +33,12 @@ def new_staff(request, guid):
     context = {"token": guid, "event": event}
     if event.staffRegStart <= today <= event.staffRegEnd or invite.ignore_time_window is True:
         return render(request, "registration/staff/staff-new.html", context)
-    return render(request, "registration/staff/staff-closed.html", context)
+    elif event.staffRegStart >= today:
+        context["message"] = "is not yet open. Please stay tuned to slack and email for updates!"
+        return render(request, "registration/staff/staff-closed.html", context)
+    elif event.staffRegEnd <= today:
+        context["message"] = "has ended."
+        return render(request, "registration/staff/staff-closed.html", context)
 
 
 @require_POST
@@ -163,7 +168,12 @@ def staff_index(request, guid):
     context = {"token": guid, "event": event}
     if event.staffRegStart <= today <= event.staffRegEnd:
         return render(request, "registration/staff/staff-locate.html", context)
-    return render(request, "registration/staff/staff-closed.html", context)
+    elif event.staffRegStart >= today:
+        context["message"] = "is not yet open. Please stay tuned to slack and email for updates!"
+        return render(request, "registration/staff/staff-closed.html", context)
+    elif event.staffRegEnd <= today:
+        context["message"] = "has ended."
+        return render(request, "registration/staff/staff-closed.html", context)
 
 
 def staff_done(request):


### PR DESCRIPTION
messages just saying "closed" whenever not open is too clunky. now it says whether it hasnt opened yet or has ended. based on times specified for open and close for each section compared to current servertime date