### PR TITLE
tweak staff copy

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -784,6 +784,8 @@ class StaffAdmin(ImportExportModelAdmin):
                     staff_copy.attendee = staff.attendee
                     staff_copy.event = event
                     staff_copy.registrationToken = getRegistrationToken()
+                    staff_copy.shirtsize = None
+                    staff_copy.checkedIn = False
                     staff_copy.save()
                     count += 1
 


### PR DESCRIPTION
the form makes staff enter a new shirt size each year on purpose as people tend to change size, so there is no point in carrying it over. if we need their last years size its available in historical data. also, reset `checkedIn` field to false.