### PR TITLE
Pin Django actions build to use 22.04

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 4
       matrix:


### PR DESCRIPTION
Github has [started rolling out Ubuntu 24.04](https://github.com/actions/runner-images/issues/10636) under the `ubuntu-latest` builder tag, but there's a dependency problem with wkhtmltox  the version back to 22.04 to make our build run until we can update that dependency.