### PR TITLE
Fix crash when SENTRY_ENABLED is undefined

### DIFF
--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -16,7 +16,7 @@ from idempotency_key import status
 
 eval_bool = lambda x: x.lower() in ('true', '1', 't', 'y', 'yes')
 
-SENTRY_ENABLED = eval_bool(os.environ.get("SENTRY_ENABLED"))
+SENTRY_ENABLED = eval_bool(os.environ.get("SENTRY_ENABLED", ""))
 if SENTRY_ENABLED:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration


### PR DESCRIPTION
Otherwise eval_bool is called on x where x is None, leading to None.lower() which causes:

AttributeError: 'NoneType' object has no attribute 'lower'

Hopefully CI works, re-created from https://github.com/furthemore/APIS/pull/340