### PR TITLE
Make gotenberg server optional in tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/furthemore/apis:apis-base-cb35d5b
+FROM ghcr.io/furthemore/apis:apis-base-3d1a81a
 
 LABEL org.opencontainers.image.source="https://github.com/furthemore/APIS"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ paho-mqtt==1.6.1
 Pillow>=5.3
 psycopg2-binary==2.9.9
 PyJWT~=2.8.0
+respx==0.22.0
 sentry-sdk
 squareup==22.0.0.20220921
 qrcode~=7.4.2


### PR DESCRIPTION
This allows tests to fallback to using a mock library to handle the HTTP request to gotenberg. I've left the option to use a real gotenberg server in case it's desired in CI or dev environments.