### PR TITLE
More quality of life tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+__pycache__/
 fm_eventmanager/dev.py
 fm_eventmanager/settings.py
 fm_eventmanager/settings.py.bak
@@ -6,6 +7,7 @@ fm_eventmanager/settings.py.bak
 venv/
 db.sqlite3
 test-db.sqlite3
+test-db.sqlite3-journal
 registration/resources/nametag/apis/tmp*.html
 .idea/
 .coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-nested-inline~=0.4.6
 django-prometheus~=2.3.1
 django-redis~=5.4.0
 #django-u2f~=1.0.1
-git+https://github.com/rechner/django-u2f.git@23022f8
+git+https://github.com/rechner/django-u2f.git@23022f80ae4af831e3533464a0b54e6ec46b2ca1
 django-widget-tweaks==1.5.0
 freezegun==1.4.0
 gotenberg-client~=0.7.0


### PR DESCRIPTION
Update .gitignore with additional entries

Add __pycache__
Add the testing db's journal file


Use full 40 character hash in depedency

This changes the django-u2f fork in requirements.txt to use the full 40 character hash instead of the abbreviated hash. This prevents the "did not find branch or tag" warning from showing since this is telling pip to explicitly use the specified commit hash.