### PR TITLE
Fix "Back to Main Page" alignment

### DIFF
--- a/registration/static/css/main.css
+++ b/registration/static/css/main.css
@@ -205,3 +205,8 @@ body > footer {
     color: white;
     font-weight: bold;
 }
+
+.link-box {
+    display: flex;
+    justify-content: space-between;
+}

--- a/registration/templates/registration/closed.html
+++ b/registration/templates/registration/closed.html
@@ -6,12 +6,14 @@
       <h1>Registration - {{ event }}</h1>
       <hr>
       <p>Registration for {{ event }} {{ message }}</p>
-      <p>If you have any questions please contact
-        <a href="mailto:{{ event.registrationEmail }}">{{ event.registrationEmail }}</a>
-      </p>
-      <p style="float:right;">
-        <a href="{{ homeRedirect }}">Back to Main Page</a>
-      </p>
+      <div class="link-box">
+        <p>If you have any questions please contact
+          <a href="mailto:{{ event.registrationEmail }}">{{ event.registrationEmail }}</a>
+        </p>
+        <p>
+          <a href="{{ homeRedirect }}">Back to Main Page</a>
+        </p>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/registration/templates/registration/dealer/dealer-closed.html
+++ b/registration/templates/registration/dealer/dealer-closed.html
@@ -6,9 +6,14 @@
       <h1>Dealer Registration - {{ event }}</h1>
       <hr>
       <p>Dealer registration for {{ event }} {{ message }}</p>
-      <p>If you have any questions please contact
-        <a href='mailto:{{ event.dealerEmail }}'>{{ event.dealerEmail }}</a></p>
-      <p style='float:right;'><a href="{% url 'registration:index' %}">Back to Main Page</a></p>
+      <div class="link-box">
+        <p>If you have any questions please contact
+          <a href="mailto:{{ event.dealerEmail }}">{{ event.dealerEmail }}</a>
+        </p>
+        <p>
+          <a href="{% url 'registration:index' %}">Back to Main Page</a>
+        </p>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/registration/templates/registration/staff/staff-closed.html
+++ b/registration/templates/registration/staff/staff-closed.html
@@ -6,12 +6,14 @@
       <h1>Staff Registration - {{ event }}</h1>
       <hr>
       <p>Staff Registration for {{ event }} {{ message }}</p>
-      <p>If you have any questions please contact
-        <a href="mailto:{{ event.staffEmail }}">{{ event.staffEmail }}</a>
-      </p>
-      <p style="float:right;">
-        <a href="{% url 'registration:index' %}">Back to Main Page</a>
-      </p>
+      <div class="link-box">
+        <p>If you have any questions please contact
+          <a href="mailto:{{ event.staffEmail }}">{{ event.staffEmail }}</a>
+        </p>
+        <p>
+          <a href="{% url 'registration:index' %}">Back to Main Page</a>
+        </p>
+      </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This changes the two links to be wrapped in a new link-box class that aligns the two elements properly.

Staff before:
![vivaldi_CXZ3AanTTZ](https://github.com/user-attachments/assets/9fff08be-e155-44bf-a19f-331404972274)
![vivaldi_6qYuXYMpHF](https://github.com/user-attachments/assets/d297c174-3681-4fad-9198-3cf703fab2b5)

Staff after:
![vivaldi_FDP9vrFQOH](https://github.com/user-attachments/assets/a40ae925-4aa7-4924-8ca7-0e18d688d6b0)
![vivaldi_8aVE0SbEi7](https://github.com/user-attachments/assets/1e504d99-6f1a-4781-87bc-3fe6122e81ad)


Same applies to the dealers closed and staff closed pages.