### PR TITLE
Update browser Sentry SDK to latest

### DIFF
--- a/registration/templates/registration/master.html
+++ b/registration/templates/registration/master.html
@@ -12,8 +12,8 @@
   <link href="{% static 'css/bootstrap-formhelpers.css' %}" rel="stylesheet" media="screen">
   <link href="{% static 'css/bootstrap-datepicker.css' %}" rel="stylesheet" media="screen">
   <script
-      src="https://browser.sentry-cdn.com/7.16.0/bundle.min.js"
-      integrity="sha384-70hBom53vQV6XVoqnEzSlfP8AYzEm6CSuti85YyRLtmm/jbx0GryCQ1z5StcQwsz"
+      src="https://browser.sentry-cdn.com/8.51.0/bundle.min.js"
+      integrity="sha384-UOoDPZa8zKe2+XR6MQctS46ElT1RITQSH47kT4eyprRgzqtUHu7xEGJCPQFZgre6"
       crossorigin="anonymous"
   ></script>
   <script>

--- a/registration/templates/registration/master_admin.html
+++ b/registration/templates/registration/master_admin.html
@@ -12,8 +12,8 @@
   <link href="{% static 'css/bootstrap-icons.css' %}" rel="stylesheet">
   <link rel="shortcut icon" type="image/png" href="{% static 'favicon.ico' %}">
   <script
-      src="https://browser.sentry-cdn.com/7.13.0/bundle.min.js"
-      integrity="sha384-r+KUPXXgkLQFWmyqriU1/6I8hKYt0wW+3XTsbVK75r6hlPjAg8TNYgEdyCuq+41e"
+      src="https://browser.sentry-cdn.com/8.51.0/bundle.min.js"
+      integrity="sha384-UOoDPZa8zKe2+XR6MQctS46ElT1RITQSH47kT4eyprRgzqtUHu7xEGJCPQFZgre6"
       crossorigin="anonymous"
   ></script>
   <script>


### PR DESCRIPTION
Simple update that brings Sentry's JS SDK up to 8.51.0 on both the admin section and the public section.