### PR TITLE
Fix new staff email using the wrong URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/furthemore/apis:apis-base-3d1a81a
+FROM ghcr.io/furthemore/apis:apis-base-ea2b3e2
 
 LABEL org.opencontainers.image.source="https://github.com/furthemore/APIS"
 

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -176,6 +176,10 @@ admin.site.register(BanList, BanListAdmin)
 
 
 def send_staff_token_email(modeladmin, request, queryset):
+    if queryset.count() == 0:
+        messages.error("Invalid token selected")
+        return
+
     for token in queryset:
         registration.emails.send_new_staff_email(token)
         token.sent = True

--- a/registration/templates/registration/emails/staff/new.html
+++ b/registration/templates/registration/emails/staff/new.html
@@ -1,6 +1,6 @@
 {% load site %}
 <h3>Welcome to {{event.name}} staff!</h3>
 <p>If you have already registered as an attendee, do not use this form. Please contact staff services to get the correct registration link.</p>
-<p>Use this link to register as staff: <a href='https://{% current_domain %}{% url 'registration:new_staff' guid=registrationToken %}'>https://{% current_domain %}{% url 'registration:staff' guid=registrationToken %}</a></p>
+<p>Use this link to register as staff: <a href='https://{% current_domain %}{% url 'registration:new_staff' guid=registrationToken %}'>https://{% current_domain %}{% url 'registration:new_staff' guid=registrationToken %}</a></p>
 <p>&nbsp;</p>
 <p>Signature</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.12.3
 configobj==5.0.9
 django>=3.2.24,<4
 django-admin-env-notice~=0.4
@@ -28,3 +29,4 @@ squareup==22.0.0.20220921
 qrcode~=7.4.2
 pytz~=2024.1
 Pygments~=2.18.0
+soupsieve==2.6


### PR DESCRIPTION
This fixes an issue where the standard staff URL is rendered within the link's text, causing those who copy/paste the link to use the wrong URL. Additionally, this fixes a crash in `send_staff_token_email` when malformed requests are sent to the token list page (i.e. selecting a token from an index which doesn't exist.

This also adds beautifulsoup as a dependency to make testing a bit more robust, as the new temp token test does a fairly thorough job of generating CSRF tokens, generating the temp token, sending the request, all from django's client using the content from the page and testing the responses on the pages as well.