### PR TITLE
Small frontend fixes

### DIFF
--- a/registration/frontend/src/admin/Onsite.tsx
+++ b/registration/frontend/src/admin/Onsite.tsx
@@ -33,7 +33,10 @@ export const Onsite: Component<{
       </div>
 
       <div class="column is-two-fifths is-narrow-tablet">
-        <Cart cartManager={props.cartManager} />
+        <Cart
+          cartManager={props.cartManager}
+          clearSearch={() => setSearchQuery("")}
+        />
       </div>
     </div>
   );

--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -125,7 +125,8 @@ export class CartManager {
   public async printBadges(
     ids: number[],
     clearCart: boolean = true,
-    mqttPrint: boolean = false
+    mqttPrint: boolean = false,
+    beforeClearingCart?: () => void
   ): Promise<FallibleRequest<BadgePrintResponse>> {
     const assignData = await this.makeRequest(this.urls.assign_badge_number, {
       method: "POST",
@@ -157,10 +158,11 @@ export class CartManager {
           url,
         })
       );
-    }
 
-    if (clearCart) {
-      await this.clearCart();
+      if (clearCart) {
+        beforeClearingCart?.();
+        await this.clearCart();
+      }
     }
 
     return printData;

--- a/registration/frontend/src/admin/cart/components/Cart.tsx
+++ b/registration/frontend/src/admin/cart/components/Cart.tsx
@@ -8,6 +8,7 @@ import { CartManager } from "../cart-manager";
 
 export const Cart: Component<{
   cartManager: CartManager;
+  clearSearch(): void;
 }> = (props) => {
   const [refresh, { refetch: refetchCart }] = createResource(
     async () => await props.cartManager.refreshCart()
@@ -16,6 +17,7 @@ export const Cart: Component<{
   const [clearing, setClearing] = createSignal<boolean>(false);
   const clear = async () => {
     setClearing(true);
+    props.clearSearch();
     await props.cartManager.clearCart();
     setClearing(false);
   };
@@ -88,6 +90,7 @@ export const Cart: Component<{
         <CartActions
           manager={props.cartManager}
           entries={props.cartManager.cartEntries()}
+          clearSearch={props.clearSearch}
         />
       </div>
 

--- a/registration/frontend/src/admin/cart/components/CartActions.tsx
+++ b/registration/frontend/src/admin/cart/components/CartActions.tsx
@@ -21,6 +21,7 @@ const PRINTABLE_STATUS = new Set(["Paid", "Comp", "Staff", "Dealer"]);
 export const CartActions: Component<{
   manager: CartManager;
   entries?: CartResponse;
+  clearSearch(): void;
 }> = (props) => {
   const config = useContext(ConfigContext)!;
   const userSettings = useContext(UserSettingsContext)!;
@@ -67,6 +68,7 @@ export const CartActions: Component<{
           printableBadgeIds(),
           setLoading,
           userSettings.userSettings().clear_cart_after_print,
+          props.clearSearch,
           true
         );
       }
@@ -145,6 +147,7 @@ export const CartActions: Component<{
                 printableBadgeIds(),
                 setLoading,
                 userSettings.userSettings().clear_cart_after_print,
+                props.clearSearch,
                 config.mqtt.supports_printing && !holdingShift
               );
             }}
@@ -208,10 +211,11 @@ async function printBadges(
   ids: number[],
   setLoading: Setter<boolean>,
   clearCart: boolean,
+  clearSearch: () => void,
   mqttPrint: boolean
 ) {
   setLoading(true);
-  const resp = await manager.printBadges(ids, clearCart, mqttPrint);
+  const resp = await manager.printBadges(ids, clearCart, mqttPrint, clearSearch);
   setLoading(false);
 
   if (!resp.success) {

--- a/registration/static/js/date-entry.js
+++ b/registration/static/js/date-entry.js
@@ -38,14 +38,11 @@ $(document).ready(function (e) {
         return;
     }
     let [year, month, day] = dob.split('-');
-    if (year) {
+    if (year && month && day) {
         $("#byear").val(year);
         $("#bmonth").val(month);
         $('#bmonth').change();
         $("#bday").val(day);
-    } else {
-        day = $('#bday').val();
-        $('#bmonth').change();
-        $('#bday').val(day);
+        $("#bday").change();
     }
 });


### PR DESCRIPTION
- Resolves an issue where when creating an attendee from an ID scan the day component of the birthday would always be the 1st (options were getting reset, causing it to always go back to the first option).
- Cleans up a behavior on the new onsite admin interface where auto-clearing the cart wouldn't work if the search had a query that only returned one result, by automatically clearing the search when clearing the cart.