### PR TITLE
Include price level option values in cart view

### DIFF
--- a/registration/frontend/src/admin/Onsite.tsx
+++ b/registration/frontend/src/admin/Onsite.tsx
@@ -1,10 +1,7 @@
 import { Component, createSignal } from "solid-js";
-import { render } from "solid-js/web";
 
-import { ApisConfig } from "../entrypoints/admin";
 import { AttendeeSearch } from "./attendee-search";
 import { Cart, CartManager } from "./cart";
-import { ConfigContext } from "./providers/config-provider";
 import { ScanPanel } from "./scan";
 import MqttClient from "./mqtt";
 

--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -245,6 +245,8 @@ export interface AttendeeOption {
   item: string;
   price: string;
   total: string;
+  optionExtraType?: "int" | "bool" | "string" | "ShirtSizes";
+  optionValue?: string;
 }
 
 export interface BadgePrintResponse {

--- a/registration/frontend/src/admin/cart/components/CartEntries.tsx
+++ b/registration/frontend/src/admin/cart/components/CartEntries.tsx
@@ -1,8 +1,18 @@
-import { Component, createMemo, For, Show } from "solid-js";
+import {
+  Component,
+  createMemo,
+  For,
+  Match,
+  Show,
+  Switch,
+  useContext,
+} from "solid-js";
 import { Big } from "big.js";
 
 import { CartBadge } from "./CartBadge";
-import { CartManager, CartResponse } from "../cart-manager";
+import { AttendeeOption, CartManager, CartResponse } from "../cart-manager";
+import { ConfigContext } from "../../providers/config-provider";
+import { ApisConfig } from "../../../entrypoints/admin";
 
 export const CartEntries: Component<{
   manager: CartManager;
@@ -69,9 +79,9 @@ export const CartEntries: Component<{
             </thead>
             <tbody>
               <For each={orderItems()}>
-                {(item, index) => (
-                  <tr data-index={index()}>
-                    <td>{`${item.quantity} × ${item.item} (@ ${item.price})`}</td>
+                {(item) => (
+                  <tr>
+                    <AttendeeOptionDescription item={item} />
                     <td>
                       <span>{item.total}</span>
                     </td>
@@ -99,6 +109,54 @@ export const CartEntries: Component<{
     </>
   );
 };
+
+const AttendeeOptionDescription: Component<{ item: AttendeeOption }> = ({
+  item,
+}) => {
+  const config = useContext(ConfigContext)!;
+
+  return (
+    <td>
+      <div>
+        {`${item.quantity} × ${item.item} (${cleanMoneyAmount(item.price)}/ea)`}
+        <Show
+          when={
+            item.optionExtraType === "ShirtSizes" ||
+            item.optionExtraType == "bool"
+          }
+        >
+          {` - `}
+          <span class="has-text-weight-bold">
+            <Switch>
+              <Match when={item.optionExtraType === "ShirtSizes"}>
+                {getShirtSizeName(config, item.optionValue)}
+              </Match>
+              <Match when={item.optionExtraType === "bool"}>
+                {item.optionValue === "True" ? "Yes" : "No"}
+              </Match>
+            </Switch>
+          </span>
+        </Show>
+      </div>
+      <Show when={item.optionExtraType === "string"}>
+        <div class="has-text-weight-bold">{item.optionValue}</div>
+      </Show>
+    </td>
+  );
+};
+
+function getShirtSizeName(
+  config: ApisConfig,
+  optionValue?: string
+): string | undefined {
+  if (!optionValue) return;
+
+  const sizeName = config.shirt_sizes.find(
+    (entry) => entry.id === parseInt(optionValue, 10)
+  )?.name;
+
+  return sizeName || optionValue;
+}
 
 export function cleanMoneyAmount(input?: string): string {
   if (!input || input == "?") return "$0.00";

--- a/registration/frontend/src/admin/cart/components/CartEntries.tsx
+++ b/registration/frontend/src/admin/cart/components/CartEntries.tsx
@@ -83,7 +83,7 @@ export const CartEntries: Component<{
                   <tr>
                     <AttendeeOptionDescription item={item} />
                     <td>
-                      <span>{item.total}</span>
+                      <span>{cleanMoneyAmount(item.total)}</span>
                     </td>
                   </tr>
                 )}

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -23,6 +23,7 @@ export interface ApisConfig {
   errors: ApisError[];
   printer_uri: string;
   mqtt: ApisMqttConfig;
+  shirt_sizes: ApisShirtSize[];
   urls: ApisUrls;
   permissions: ApisPermissions;
   terminals: ApisTerminalSettings;
@@ -51,6 +52,11 @@ export interface ApisMqttAuth {
   user: string;
   token: string;
   base_topic: string;
+}
+
+export interface ApisShirtSize {
+  id: number;
+  name: string;
 }
 
 export interface ApisUrls {

--- a/registration/models.py
+++ b/registration/models.py
@@ -78,7 +78,11 @@ def content_file_name(instance, filename):
 class PriceLevelOption(models.Model):
     optionName = models.CharField(max_length=200)
     optionPrice = models.DecimalField(max_digits=6, decimal_places=2)
-    optionExtraType = models.CharField(max_length=100, blank=True)
+    optionExtraType = models.CharField(
+        max_length=100,
+        blank=True,
+        choices=[("int", "Quantity"), ("bool", "Yes/No"), ("ShirtSizes", "Shirt Size"), ("string", "String")],
+    )
     optionExtraType2 = models.CharField(max_length=100, blank=True)
     optionExtraType3 = models.CharField(max_length=100, blank=True)
     optionImage = models.ImageField(upload_to=content_file_name, blank=True, null=True)


### PR DESCRIPTION
Adds the price level option values into the cart view, for easy viewing of shirt sizes, etc. Also updates the `PriceLevelOption` model to list the `optionExtraType` as a choice instead of free text to ensure everything keeps working as expected. The UI can correctly render all of the current option types (int aka quantity, bool, ShirtSizes, and string).

![Screen Shot 2025-02-08 at 21 50 12](https://github.com/user-attachments/assets/4ca57c8e-3b46-4e1f-b60a-8acc473c3484)
