### PR TITLE
Make next customer clear out everything

### DIFF
--- a/registration/frontend/src/admin/Navbar.tsx
+++ b/registration/frontend/src/admin/Navbar.tsx
@@ -1,16 +1,18 @@
-import { ApisConfig, CSRF_TOKEN } from "../entrypoints/admin";
+import { Dialog } from "@kobalte/core/dialog";
+import { createShortcut, KbdKey } from "@solid-primitives/keyboard";
 import { Big } from "big.js";
 import {
   Component,
   createEffect,
   createSignal,
   For,
+  Setter,
   Show,
   useContext,
 } from "solid-js";
+
+import { ApisConfig, CSRF_TOKEN } from "../entrypoints/admin";
 import { ConfigContext } from "./providers/config-provider";
-import { createShortcut, KbdKey } from "@solid-primitives/keyboard";
-import { Dialog } from "@kobalte/core/dialog";
 import {
   UserSettingKey,
   UserSettingsContext,
@@ -123,7 +125,10 @@ async function amountRequest(url: string, message: string) {
   }
 }
 
-const Actions: Component<{ config: ApisConfig }> = (props) => {
+const Actions: Component<{
+  config: ApisConfig;
+  setReadyForNext: Setter<boolean>;
+}> = (props) => {
   return (
     <div class="navbar-dropdown is-right">
       <ActionButton
@@ -144,7 +149,10 @@ const Actions: Component<{ config: ApisConfig }> = (props) => {
         name="Next Customer"
         icon="fas fa-forward"
         keyboardShortcut={["Alt", "N"]}
-        action={() => makeSimpleRequest(props.config.urls.ready_terminal)}
+        action={() => {
+          makeSimpleRequest(props.config.urls.ready_terminal);
+          props.setReadyForNext(true);
+        }}
       />
 
       <Show when={props.config.permissions.cash_admin}>
@@ -291,7 +299,9 @@ const ToggleSetting: Component<{
   );
 };
 
-export const Navbar: Component = () => {
+export const Navbar: Component<{
+  setReadyForNext: Setter<boolean>;
+}> = (props) => {
   const config = useContext(ConfigContext)!;
   const userSettings = useContext(UserSettingsContext)!;
 
@@ -366,7 +376,7 @@ export const Navbar: Component = () => {
               <i class="fas fa-cog"></i>
             </a>
 
-            <Actions config={config} />
+            <Actions config={config} setReadyForNext={props.setReadyForNext} />
           </div>
 
           <div class="navbar-item has-dropdown is-hoverable">

--- a/registration/frontend/src/admin/Onsite.tsx
+++ b/registration/frontend/src/admin/Onsite.tsx
@@ -1,15 +1,31 @@
-import { Component, createSignal } from "solid-js";
+import {
+  Accessor,
+  Component,
+  createEffect,
+  createSignal,
+  Setter,
+} from "solid-js";
 
 import { AttendeeSearch } from "./attendee-search";
 import { Cart, CartManager } from "./cart";
-import { ScanPanel } from "./scan";
 import MqttClient from "./mqtt";
+import { ScanPanel } from "./scan";
 
 export const Onsite: Component<{
   mqtt: MqttClient;
   cartManager: CartManager;
+  readyForNext: Accessor<boolean>;
+  setReadyForNext: Setter<boolean>;
 }> = (props) => {
   const [searchQuery, setSearchQuery] = createSignal<string>();
+
+  createEffect(async () => {
+    if (props.readyForNext()) {
+      setSearchQuery("");
+      await props.cartManager.clearCart();
+      props.setReadyForNext(false);
+    }
+  });
 
   return (
     <div class="columns">
@@ -25,6 +41,7 @@ export const Onsite: Component<{
             const query = birthday ? `${name} birthday:${birthday}` : name;
             setSearchQuery(query);
           }}
+          readyForNext={props.readyForNext}
           emitter={props.mqtt.emitter}
         />
       </div>

--- a/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
+++ b/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
@@ -1,3 +1,4 @@
+import { createShortcut } from "@solid-primitives/keyboard";
 import {
   Accessor,
   Component,
@@ -9,14 +10,13 @@ import {
   Show,
   useContext,
 } from "solid-js";
-import { createShortcut } from "@solid-primitives/keyboard";
 
-import { BadgeTableLoader } from "./BadgeTableLoader";
-import { BadgeTableRow } from "./BadgeTableRow";
-import { CartManager } from "../../cart";
-import { ConfigContext } from "../../providers/config-provider";
 import { getSearchResults } from "..";
 import { SentryErrorBoundary } from "../../../entrypoints/admin";
+import { CartManager } from "../../cart";
+import { ConfigContext } from "../../providers/config-provider";
+import { BadgeTableLoader } from "./BadgeTableLoader";
+import { BadgeTableRow } from "./BadgeTableRow";
 
 export const AttendeeSearch: Component<{
   cartManager: CartManager;

--- a/registration/frontend/src/admin/cart/components/ActionButton.tsx
+++ b/registration/frontend/src/admin/cart/components/ActionButton.tsx
@@ -1,3 +1,4 @@
+import { createShortcut, KbdKey } from "@solid-primitives/keyboard";
 import {
   Component,
   createEffect,
@@ -6,7 +7,6 @@ import {
   JSX,
   Setter,
 } from "solid-js";
-import { createShortcut, KbdKey } from "@solid-primitives/keyboard";
 
 export type ActionButtonProps = {
   class: string;

--- a/registration/frontend/src/admin/cart/components/Cart.tsx
+++ b/registration/frontend/src/admin/cart/components/Cart.tsx
@@ -1,10 +1,10 @@
-import { Component, createResource, createSignal } from "solid-js";
 import { createShortcut } from "@solid-primitives/keyboard";
+import { Component, createResource, createSignal } from "solid-js";
 import { Show } from "solid-js/web";
 
+import { CartManager } from "../cart-manager";
 import { CartActions } from "./CartActions";
 import { CartEntries } from "./CartEntries";
-import { CartManager } from "../cart-manager";
 
 export const Cart: Component<{
   cartManager: CartManager;
@@ -27,8 +27,7 @@ export const Cart: Component<{
     await props.cartManager.removeBadge(id);
   });
 
-  const anythingLoading = () =>
-    refresh.loading || clearing() || remove.loading;
+  const anythingLoading = () => refresh.loading || clearing() || remove.loading;
 
   createShortcut(["Alt", "R"], () => {
     if (anythingLoading()) return;

--- a/registration/frontend/src/admin/cart/components/CartActions.tsx
+++ b/registration/frontend/src/admin/cart/components/CartActions.tsx
@@ -1,3 +1,4 @@
+import { Big } from "big.js";
 import {
   Accessor,
   Component,
@@ -7,14 +8,13 @@ import {
   Setter,
   useContext,
 } from "solid-js";
-import { Big } from "big.js";
 
-import { ActionButton } from "./ActionButton";
-import { Badge, CartManager, CartResponse } from "../cart-manager";
-import { CartActionsError } from "./CartActionsError";
-import { ConfigContext } from "../../providers/config-provider";
 import { SentryErrorBoundary } from "../../../entrypoints/admin";
+import { ConfigContext } from "../../providers/config-provider";
 import { UserSettingsContext } from "../../providers/user-settings-provider";
+import { Badge, CartManager, CartResponse } from "../cart-manager";
+import { ActionButton } from "./ActionButton";
+import { CartActionsError } from "./CartActionsError";
 
 const PRINTABLE_STATUS = new Set(["Paid", "Comp", "Staff", "Dealer"]);
 
@@ -215,7 +215,12 @@ async function printBadges(
   mqttPrint: boolean
 ) {
   setLoading(true);
-  const resp = await manager.printBadges(ids, clearCart, mqttPrint, clearSearch);
+  const resp = await manager.printBadges(
+    ids,
+    clearCart,
+    mqttPrint,
+    clearSearch
+  );
   setLoading(false);
 
   if (!resp.success) {

--- a/registration/frontend/src/admin/cart/components/CartEntries.tsx
+++ b/registration/frontend/src/admin/cart/components/CartEntries.tsx
@@ -1,3 +1,4 @@
+import { Big } from "big.js";
 import {
   Component,
   createMemo,
@@ -7,12 +8,11 @@ import {
   Switch,
   useContext,
 } from "solid-js";
-import { Big } from "big.js";
 
-import { CartBadge } from "./CartBadge";
-import { AttendeeOption, CartManager, CartResponse } from "../cart-manager";
-import { ConfigContext } from "../../providers/config-provider";
 import { ApisConfig } from "../../../entrypoints/admin";
+import { ConfigContext } from "../../providers/config-provider";
+import { AttendeeOption, CartManager, CartResponse } from "../cart-manager";
+import { CartBadge } from "./CartBadge";
 
 export const CartEntries: Component<{
   manager: CartManager;

--- a/registration/frontend/src/admin/cart/index.ts
+++ b/registration/frontend/src/admin/cart/index.ts
@@ -1,4 +1,4 @@
-import { Cart } from "./components/Cart";
 import { CartManager, CartResponse } from "./cart-manager";
+import { Cart } from "./components/Cart";
 
 export { Cart, CartManager, CartResponse };

--- a/registration/frontend/src/admin/scan/components/IdEntry.tsx
+++ b/registration/frontend/src/admin/scan/components/IdEntry.tsx
@@ -1,10 +1,10 @@
-import { Component, createMemo, Show, useContext } from "solid-js";
 import { createShortcut } from "@solid-primitives/keyboard";
 import { differenceInYears } from "date-fns/differenceInYears";
+import { Component, createMemo, Show, useContext } from "solid-js";
 
-import { CloseButton } from "./CloseButton";
-import { ConfigContext } from "../../providers/config-provider";
 import { IdData } from "..";
+import { ConfigContext } from "../../providers/config-provider";
+import { CloseButton } from "./CloseButton";
 import { NameBirthday } from "./ScanPii";
 
 export const IdEntry: Component<{ data: IdData; remove(): void }> = (props) => {

--- a/registration/frontend/src/admin/scan/components/ScanPanel.tsx
+++ b/registration/frontend/src/admin/scan/components/ScanPanel.tsx
@@ -1,10 +1,10 @@
-import { Component, createEffect, createMemo, Show } from "solid-js";
 import { createShortcut } from "@solid-primitives/keyboard";
+import { Accessor, Component, createEffect, createMemo, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import { IdData, ShcData } from "..";
-import { IdEntry } from "./IdEntry";
 import { MqttEmitter } from "../../mqtt";
+import { IdEntry } from "./IdEntry";
 import { ShcEntry } from "./ShcEntry";
 import { UrlEntry } from "./UrlEntry";
 
@@ -16,6 +16,7 @@ type ScanStore = {
 
 export const ScanPanel: Component<{
   gotScannedName(name: string, birthday?: string): void;
+  readyForNext: Accessor<boolean>;
   emitter: MqttEmitter;
 }> = (props) => {
   const [store, setStore] = createStore<ScanStore>({
@@ -27,6 +28,12 @@ export const ScanPanel: Component<{
   const clear = () => {
     setStore({ id: undefined, shc: undefined, url: undefined });
   };
+
+  createEffect(() => {
+    if (props.readyForNext()) {
+      clear();
+    }
+  });
 
   let panel!: HTMLDivElement;
 

--- a/registration/frontend/src/admin/scan/components/ScanPii.tsx
+++ b/registration/frontend/src/admin/scan/components/ScanPii.tsx
@@ -1,8 +1,8 @@
-import { Component } from "solid-js";
 import { differenceInYears } from "date-fns/differenceInYears";
+import { Component } from "solid-js";
 
-import { MismatchedData } from "./MismatchedData";
 import { ShcMatch } from "..";
+import { MismatchedData } from "./MismatchedData";
 
 export const NameBirthday: Component<{
   name: string;

--- a/registration/frontend/src/admin/scan/components/ShcEntry.tsx
+++ b/registration/frontend/src/admin/scan/components/ShcEntry.tsx
@@ -1,8 +1,8 @@
 import { Component, For, Match, Show, Switch } from "solid-js";
 
+import { ShcData, ShcMatch } from "..";
 import { CloseButton } from "./CloseButton";
 import { NameBirthday } from "./ScanPii";
-import { ShcData, ShcMatch } from "..";
 
 export const ShcEntry: Component<{
   data: ShcData;

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -1,13 +1,14 @@
-import { ErrorBoundary, For, render } from "solid-js/web";
 import * as Sentry from "@sentry/solid";
+import { createSignal } from "solid-js";
+import { ErrorBoundary, For, render } from "solid-js/web";
 
-import { ConfigContext } from "../admin/providers/config-provider";
 import { Navbar } from "../admin/Navbar";
 import { Onsite } from "../admin/Onsite";
+import { ConfigContext } from "../admin/providers/config-provider";
 
+import { CartManager } from "../admin/cart";
 import "../admin/index.scss";
 import MqttClient from "../admin/mqtt";
-import { CartManager } from "../admin/cart";
 import {
   UserSettingsContext,
   UserSettingsManager,
@@ -151,11 +152,13 @@ function start() {
     return;
   }
 
+  const [readyForNext, setReadyForNext] = createSignal(false);
+
   render(() => {
     return (
       <ConfigContext.Provider value={APIS_CONFIG}>
         <UserSettingsContext.Provider value={userSettings}>
-          <Navbar />
+          <Navbar setReadyForNext={setReadyForNext} />
 
           <For each={APIS_CONFIG.errors}>
             {(error) => (
@@ -172,7 +175,12 @@ function start() {
                 userSettings.userSettings().container_fluid,
             }}
           >
-            <Onsite mqtt={mqtt} cartManager={cartManager} />
+            <Onsite
+              mqtt={mqtt}
+              cartManager={cartManager}
+              readyForNext={readyForNext}
+              setReadyForNext={setReadyForNext}
+            />
           </div>
         </UserSettingsContext.Provider>
       </ConfigContext.Provider>


### PR DESCRIPTION
This makes the "Next Customer" button significantly more useful, by clearing the cart, searches, and ID scans.

Also makes imports consistent across all frontend files.