### PR TITLE
Fix crash in onsite admin when printer URI isn't set

### DIFF
--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -124,7 +124,7 @@ def onsite_admin(request):
                 "release": getattr(settings, "SENTRY_RELEASE", None),
             },
             "errors": errors,
-            "printer_uri": settings.REGISTER_PRINTER_URI,
+            "printer_uri": getattr(settings, "REGISTER_PRINTER_URI", ""),
             "mqtt": {
                 "broker": getattr(settings, "MQTT_EXTERNAL_BROKER", None),
                 "auth": mqtt_auth,


### PR DESCRIPTION
There's a few more subtle bugs that pop up that I'll tackle at some point related to missing configuration values / missing binaries, but this at least gets the page to load so you can click around for those who don't have a printer set up for local dev environments.