### PR TITLE
Fix new terminal topics

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -132,7 +132,7 @@ class FirebaseAdmin(admin.ModelAdmin):
             "mqttPort": 443,
             "mqttUsername": token["user"],
             "mqttPassword": token["token"],
-            "mqttTopic": mqtt.get_topic("terminal", firebase.name),
+            "mqttTopic": f'{mqtt.get_topic("terminal", firebase.name)}/action',
             "squareApplicationId": settings.SQUARE_APPLICATION_ID,
             "squareLocationId": settings.REGISTER_SQUARE_LOCATION,
         }

--- a/registration/tests/test_admin_firebase.py
+++ b/registration/tests/test_admin_firebase.py
@@ -45,7 +45,7 @@ class TestFirebaseAdmin(TestCase):
             "mqttPort": 443,
             "mqttUsername": token["user"],
             "mqttPassword": token["token"],
-            "mqttTopic": mqtt.get_topic("terminal", firebase.name),
+            "mqttTopic": f'{mqtt.get_topic("terminal", firebase.name)}/action',
             "squareApplicationId": settings.SQUARE_APPLICATION_ID,
             "squareLocationId": settings.REGISTER_SQUARE_LOCATION,
         }

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -302,7 +302,7 @@ def send_mqtt_message_to_terminal(request: Union[HttpRequest, Firebase], data: d
             return JsonResponse({"sucess": False, "reason": "No terminal associated with request"}, status=400)
 
     name = active.name
-    topic = mqtt.get_topic("terminal", name)
+    topic = f'{mqtt.get_topic("terminal", name)}/action'
 
     try:
         mqtt.send_mqtt_message(topic, data)


### PR DESCRIPTION
The MQTT permissions only allow topics under the terminal name, so update the topics to use that.