### PR TITLE
Only delete old order if it exists

### DIFF
--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -537,7 +537,7 @@ def combine_orders(orders):
         for order_item in order_items:
             old_order = order_item.order
             order_item.order = first_order
-            if old_order:
+            if old_order and old_order.id:
                 logger.warning("Deleting old order id={0}".format(old_order.id))
                 old_order.delete()
             order_item.save()

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -537,8 +537,9 @@ def combine_orders(orders):
         for order_item in order_items:
             old_order = order_item.order
             order_item.order = first_order
-            logger.warning("Deleting old order id={0}".format(old_order.id))
-            old_order.delete()
+            if old_order:
+                logger.warning("Deleting old order id={0}".format(old_order.id))
+                old_order.delete()
             order_item.save()
 
         first_order.save()


### PR DESCRIPTION
This causes an issue with combining orders where if the order being merged into the existing order has multiple items, it causes an error trying to delete the order multiple times.