### PR TITLE
Show staff shirt sizes, other onsite layout improvements

### DIFF
--- a/registration/frontend/src/admin/attendee-search/index.ts
+++ b/registration/frontend/src/admin/attendee-search/index.ts
@@ -5,7 +5,7 @@ export { AttendeeSearch };
 
 export interface BadgeResult {
   id: number;
-  edit_url: string;
+  editUrl: string;
   attendee: Attendee;
   badgeName: string;
   badgeNumber?: number;

--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -253,6 +253,7 @@ export interface Badge {
   level_total: string;
   attendee_options: AttendeeOption[];
   reference: string;
+  staff?: Staff;
 }
 
 export interface EffectiveLevel {
@@ -275,6 +276,10 @@ export interface AttendeeOption {
   reason?: string;
   optionExtraType?: "int" | "bool" | "string" | "ShirtSizes";
   optionValue?: string;
+}
+
+export interface Staff {
+  shirtSize: string;
 }
 
 export interface BadgePrintResponse {

--- a/registration/frontend/src/admin/cart/components/CartActions.tsx
+++ b/registration/frontend/src/admin/cart/components/CartActions.tsx
@@ -104,6 +104,19 @@ export const CartActions: Component<{
         )}
       >
         <div class="columns">
+          <ActionButton
+            class="is-link is-outlined"
+            disabled={!allBadgesPaid()}
+            loading={loading()}
+            setLoading={setLoading}
+            action={() => printReceipts(props.manager)}
+          >
+            <span class="icon">
+              <i class="fas fa-receipt"></i>
+            </span>
+            <span>Receipt</span>
+          </ActionButton>
+
           <Show
             when={config.permissions.cash}
             fallback={<div class="column"></div>}
@@ -127,7 +140,7 @@ export const CartActions: Component<{
               <span class="icon">
                 <i class="fas fa-money-bill-alt"></i>
               </span>
-              <span>Tender Cash</span>
+              <span>Cash</span>
             </ActionButton>
           </Show>
 
@@ -142,7 +155,7 @@ export const CartActions: Component<{
             <span class="icon">
               <i class="fas fa-credit-card"></i>
             </span>
-            <span>Credit/Debit Card</span>
+            <span>Card</span>
           </ActionButton>
         </div>
 
@@ -161,25 +174,10 @@ export const CartActions: Component<{
               <span class="icon">
                 <i class="fas fa-gift"></i>
               </span>
-              <span>Create Discount</span>
+              <span>Discount</span>
             </ActionButton>
           </Show>
 
-          <ActionButton
-            class="is-link is-outlined"
-            disabled={!allBadgesPaid()}
-            loading={loading()}
-            setLoading={setLoading}
-            action={() => printReceipts(props.manager)}
-          >
-            <span class="icon">
-              <i class="fas fa-receipt"></i>
-            </span>
-            <span>Print Receipt</span>
-          </ActionButton>
-        </div>
-
-        <div class="columns">
           <ActionButton
             class="is-link"
             disabled={!hasPrintableBadges()}

--- a/registration/frontend/src/admin/cart/components/CartBadge.tsx
+++ b/registration/frontend/src/admin/cart/components/CartBadge.tsx
@@ -90,7 +90,7 @@ export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
         </div>
 
         <div class="message-body p-0">
-          <table class="table is-fullwidth is-condensed">
+          <table class="table is-fullwidth is-narrow">
             <thead>
               <tr>
                 <th style="width: 60%;">Badge</th>
@@ -111,6 +111,16 @@ export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
                 <td>{props.badge.effectiveLevel?.name || ""}</td>
                 <td>{cleanMoneyAmount(props.badge.effectiveLevel?.price)}</td>
               </tr>
+              <Show when={props.badge.staff}>
+                <tr>
+                  <td colSpan={3}>
+                    <span>
+                      {`Staff Shirt – `}
+                      <span class="has-text-weight-semibold">{props.badge.staff?.shirtSize || "None"}</span>
+                    </span>
+                  </td>
+                </tr>
+              </Show>
             </tbody>
           </table>
         </div>

--- a/registration/frontend/src/admin/cart/components/CartEntries.tsx
+++ b/registration/frontend/src/admin/cart/components/CartEntries.tsx
@@ -46,35 +46,6 @@ export const CartEntries: Component<{
 
   return (
     <>
-      <div class="panel-block">
-        <table class="table is-fullwidth is-narrow">
-          <tbody>
-            <tr>
-              <td>Subtotal:</td>
-              <td style="width: 20%;">
-                {cleanMoneyAmount(props.entries?.subtotal)}
-              </td>
-            </tr>
-            <tr>
-              <td>Discounts:</td>
-              <td>{cleanMoneyAmount(props.entries?.total_discount)}</td>
-            </tr>
-            <tr>
-              <td>Donation to Charity:</td>
-              <td>{cleanMoneyAmount(props.entries?.charityDonation)}</td>
-            </tr>
-            <tr>
-              <td>Donation to Convention:</td>
-              <td>{cleanMoneyAmount(props.entries?.orgDonation)}</td>
-            </tr>
-            <tr class="has-text-weight-semibold">
-              <td>Total:</td>
-              <td>{cleanMoneyAmount(props.entries?.total)}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
       <Show when={(orderItems()?.length || 0) > 0}>
         <div class="panel-block">
           <table class="table is-fullwidth is-narrow">
@@ -113,6 +84,35 @@ export const CartEntries: Component<{
           </For>
         </article>
       </Show>
+
+      <div class="panel-block">
+        <table class="table is-fullwidth is-narrow">
+          <tbody>
+            <tr>
+              <td>Subtotal:</td>
+              <td style="width: 20%;">
+                {cleanMoneyAmount(props.entries?.subtotal)}
+              </td>
+            </tr>
+            <tr>
+              <td>Discounts:</td>
+              <td>{cleanMoneyAmount(props.entries?.total_discount)}</td>
+            </tr>
+            <tr>
+              <td>Donation to Charity:</td>
+              <td>{cleanMoneyAmount(props.entries?.charityDonation)}</td>
+            </tr>
+            <tr>
+              <td>Donation to Convention:</td>
+              <td>{cleanMoneyAmount(props.entries?.orgDonation)}</td>
+            </tr>
+            <tr class="has-text-weight-semibold">
+              <td>Total:</td>
+              <td>{cleanMoneyAmount(props.entries?.total)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </>
   );
 };
@@ -168,15 +168,22 @@ function getShirtSizeName(
 export function cleanMoneyAmount(input?: string): string {
   if (!input || input == "?") return "$0.00";
 
+  let multi = 1;
+  if (input.startsWith("-")) {
+    multi = -1;
+    input = input.substring(1);
+  }
+
   if (input.startsWith("$")) {
     input = input.substring(1);
   }
 
+
   let parsed: Big;
   try {
-    parsed = new Big(input);
+    parsed = new Big(input).mul(multi);
   } catch (err) {
-    console.error(`Could not parse money: ${err}`);
+    console.error(`Could not parse money ${input}: ${err}`);
     return input;
   }
 

--- a/registration/frontend/src/admin/cart/components/CartEntries.tsx
+++ b/registration/frontend/src/admin/cart/components/CartEntries.tsx
@@ -47,7 +47,7 @@ export const CartEntries: Component<{
   return (
     <>
       <div class="panel-block">
-        <table class="table is-fullwidth is-condensed">
+        <table class="table is-fullwidth is-narrow">
           <tbody>
             <tr>
               <td>Subtotal:</td>
@@ -77,7 +77,7 @@ export const CartEntries: Component<{
 
       <Show when={(orderItems()?.length || 0) > 0}>
         <div class="panel-block">
-          <table class="table is-fullwidth is-condensed">
+          <table class="table is-fullwidth is-narrow">
             <thead>
               <tr>
                 <th>Order Item</th>

--- a/registration/models.py
+++ b/registration/models.py
@@ -533,9 +533,9 @@ class Badge(models.Model):
 
     @property
     def abandoned(self):
-        if Staff.objects.filter(attendee=self.attendee).exists():
+        if Staff.objects.filter(attendee=self.attendee, event=self.event).exists():
             return Badge.STAFF
-        if Dealer.objects.filter(attendee=self.attendee).exists():
+        if Dealer.objects.filter(attendee=self.attendee, event=self.event).exists():
             return Badge.DEALER
         if self.paidTotal() > 0:
             return Badge.PAID

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -34,6 +34,7 @@ from registration.models import (
     Order,
     OrderItem,
     ShirtSizes,
+    Staff,
     get_token,
 )
 from registration.views.attendee import get_attendee_age
@@ -211,7 +212,7 @@ def onsite_admin_search(request):
         for badge in badges:
             data.append({
                 "id": badge.id,
-                "edit_url": reverse("admin:registration_badge_change", args=(badge.id,)),
+                "editUrl": reverse("admin:registration_badge_change", args=(badge.id,)),
                 "attendee": {
                     "firstName": badge.attendee.firstName,
                     "lastName": badge.attendee.lastName,
@@ -884,6 +885,15 @@ def build_result(cart):
         )
         total_discount += level_discount
 
+        staff_data = None
+
+        if badge.abandoned == Badge.STAFF:
+            staff = Staff.objects.get(event=badge.event, attendee=badge.attendee)
+
+            staff_data = {
+                "shirtSize": staff.shirtsize.name if staff.shirtsize else None,
+            }
+
         item = {
             "id": badge.id,
             "firstName": badge.attendee.preferredName or badge.attendee.firstName,
@@ -901,6 +911,7 @@ def build_result(cart):
             "attendee_options": attendee_options,
             "printed": badge.printed,
             "reference": order.reference,
+            "staff": staff_data,
         }
         result.append(item)
 


### PR DESCRIPTION
- Flattens cart actions to two rows instead of three
- Decreases padding on all cart tables to fit more information without scrolling
- Similarly, moves the totals to the bottom so more cart entries are visible
- Show staff shirt sizes in card

![Screenshot 2025-03-11 at 4 31 30 PM](https://github.com/user-attachments/assets/d8d2d499-8184-40b1-8315-c1604d7d6dd7)
