### PR TITLE
Support arbitrary ID types, fix cart auto add logic

### DIFF
--- a/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
+++ b/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
@@ -8,15 +8,48 @@ import {
   For,
   Setter,
   Show,
+  untrack,
   useContext,
 } from "solid-js";
 
-import { getSearchResults } from "..";
+import { BadgeResult, getSearchResults } from "..";
 import { SentryErrorBoundary } from "../../../entrypoints/admin";
 import { CartManager } from "../../cart";
 import { ConfigContext } from "../../providers/config-provider";
 import { BadgeTableLoader } from "./BadgeTableLoader";
 import { BadgeTableRow } from "./BadgeTableRow";
+
+function hasAnyExactMatch(query: string, badge: BadgeResult): boolean {
+  const fullName = `${badge.attendee.firstName.trim()} ${badge.attendee.lastName.trim()}`;
+  const preferredName = `${badge.attendee.preferredName?.trim()} ${badge.attendee.lastName.trim()}`;
+
+  if (
+    fullName.localeCompare(query, undefined, {
+      sensitivity: "base",
+    }) === 0
+  ) {
+    return true;
+  }
+
+  if (
+    badge.attendee.preferredName &&
+    preferredName.localeCompare(query, undefined, {
+      sensitivity: "base",
+    }) === 0
+  ) {
+    return true;
+  }
+
+  if (
+    badge.badgeName
+      .trim()
+      .localeCompare(query, undefined, { sensitivity: "base" }) === 0
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 export const AttendeeSearch: Component<{
   cartManager: CartManager;
@@ -58,9 +91,30 @@ export const AttendeeSearch: Component<{
 
   createEffect(() => {
     const entries = results();
-    if (entries && entries.length === 1) {
+    const searchQuery = untrack(() => props.searchQuery()) || "";
+
+    if (entries && entries.length > 0) {
       setSelectedResult(0);
-      if (!props.cartManager.alreadyInCart(entries[0].id)) {
+
+      const cleanedSearchQuery = searchQuery
+        .replace(/ birthday:(?:[0-9-]{10})/, "")
+        .trim();
+
+      const firstResultHasExact = hasAnyExactMatch(
+        cleanedSearchQuery,
+        entries[0]
+      );
+      const anyOtherResultHasExact =
+        firstResultHasExact &&
+        entries
+          .slice(1)
+          .some((entry) => hasAnyExactMatch(cleanedSearchQuery, entry));
+
+      if (
+        !props.cartManager.alreadyInCart(entries[0].id) &&
+        firstResultHasExact &&
+        !anyOtherResultHasExact
+      ) {
         props.cartManager.addCartId(entries[0].id);
       }
     } else {

--- a/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
+++ b/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
@@ -158,7 +158,7 @@ export const AttendeeSearch: Component<{
     const selected = selectedResult();
 
     if (selected && entries?.[selected]) {
-      window.open(entries[selected].edit_url, "edit");
+      window.open(entries[selected].editUrl, "edit");
     }
   });
 

--- a/registration/frontend/src/admin/attendee-search/components/BadgeTableRow.tsx
+++ b/registration/frontend/src/admin/attendee-search/components/BadgeTableRow.tsx
@@ -84,7 +84,7 @@ export const BadgeTableRow: Component<{
       <td class="is-vcentered">
         <div class="buttons is-right badge-actions">
           <a
-            href={props.badge.edit_url}
+            href={props.badge.editUrl}
             target="edit"
             class="button is-small is-info"
           >

--- a/registration/frontend/src/admin/scan/components/IdEntry.tsx
+++ b/registration/frontend/src/admin/scan/components/IdEntry.tsx
@@ -27,12 +27,15 @@ export const IdEntry: Component<{ data: IdData; remove(): void }> = (props) => {
     url.searchParams.set("firstName", props.data.first);
     url.searchParams.set("lastName", props.data.last);
     url.searchParams.set("dob", props.data.dob);
-    url.searchParams.set("address1", props.data.address);
-    if (props.data.address2)
-      url.searchParams.set("address2", props.data.address2);
-    url.searchParams.set("city", props.data.city);
-    url.searchParams.set("state", props.data.state);
-    url.searchParams.set("postalCode", props.data.ZIP.substring(0, 5));
+    if (props.data.address) {
+      const address = props.data.address;
+      url.searchParams.set("address1", address.address);
+      if (address.address2) url.searchParams.set("address2", address.address2);
+      url.searchParams.set("city", address.city);
+      url.searchParams.set("state", address.state);
+      url.searchParams.set("postalCode", address.ZIP.substring(0, 5));
+    }
+
     return url.toString();
   });
 
@@ -53,7 +56,7 @@ export const IdEntry: Component<{ data: IdData; remove(): void }> = (props) => {
           <span class="icon">
             <i class="fa-solid fa-id-card"></i>
           </span>
-          <span>ID Card</span>
+          <span>{`ID Card (${props.data.documentType})`}</span>
         </span>
 
         <div class="is-flex-grow-1">

--- a/registration/frontend/src/admin/scan/index.ts
+++ b/registration/frontend/src/admin/scan/index.ts
@@ -1,14 +1,17 @@
-import { createSignal } from "solid-js";
-
 import { ScanPanel } from "./components/ScanPanel";
 
 export { ScanPanel };
 
 export interface IdData {
+  documentType: string;
   first: string;
   last: string;
   dob: string;
   expiry: string;
+  address?: AddressData;
+}
+
+export interface AddressData {
   address: string;
   address2: string;
   city: string;
@@ -38,19 +41,7 @@ export interface ShcVaccine {
   performer: string;
 }
 
-export interface ScanLog {
-  url: string | undefined;
-  id: IdData | undefined;
-  shc: ShcData | undefined;
-}
-
 export interface ShcMatch {
   name: boolean;
   dob: boolean;
 }
-
-const [scanLog, setScanLog] = createSignal<ScanLog>({
-  url: undefined,
-  id: undefined,
-  shc: undefined,
-});


### PR DESCRIPTION
- Makes ID card in onsite admin more generic, allowing for future ID scan types (passports, CACs)
- Fixes logic for automatically adding results to cart (will only add results that have the only exact match)