### PR TITLE
MQTT and Sentry improvements, add entire order to cart

### DIFF
--- a/registration/frontend/src/admin/mqtt.ts
+++ b/registration/frontend/src/admin/mqtt.ts
@@ -36,14 +36,17 @@ export default class MqttClient {
     if (!this.config.auth) return;
 
     const wildcardTopic = this.getPrefixedTopic("#");
-    const randomClientId = Math.random().toString(16).substr(2, 8);
 
     this.client = mqtt.connect(config.broker, {
       username: config.auth.user,
       password: config.auth.token,
-      clientId: `${config.auth.user}-${randomClientId}`,
-      clean: true,
+      clientId: `admin-${config.auth.user}`,
+      clean: false,
+      protocolVersion: 5,
       timerVariant: "native",
+      properties: {
+        sessionExpiryInterval: 300,
+      },
     });
 
     this.client.on("connect", () => {

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -19,7 +19,7 @@ declare global {
 }
 
 export interface ApisConfig {
-  debug: boolean;
+  user: ApisUser;
   sentry: ApisSentry;
   errors: ApisError[];
   mqtt: ApisMqttConfig;
@@ -27,6 +27,12 @@ export interface ApisConfig {
   urls: ApisUrls;
   permissions: ApisPermissions;
   terminals: ApisTerminalSettings;
+}
+
+export interface ApisUser {
+  id: number;
+  email: string;
+  station?: string;
 }
 
 export interface ApisSentry {
@@ -115,6 +121,15 @@ if (APIS_CONFIG.sentry.enabled) {
       return event;
     },
   });
+
+  Sentry.setUser({
+    id: APIS_CONFIG.user.id,
+    email: APIS_CONFIG.user.email,
+  });
+
+  if (APIS_CONFIG.user.station) {
+    Sentry.setTag("onsite_station", APIS_CONFIG.user.station);
+  }
 }
 
 export const SentryErrorBoundary =


### PR DESCRIPTION
A number of relatively small changes for the onsite admin UI:

- Add user and terminal information to Sentry errors
- When adding badges to cart, add all badges in order
- Don't clean MQTT session and use a fixed client ID per station