### PR TITLE
Add onsite cart transfers

### DIFF
--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -12,17 +12,42 @@ export class CartManager {
   public cartEntries: Accessor<CartResponse | undefined>;
   private setCartEntries: Setter<CartResponse | undefined>;
 
+  public pendingTransfers: Accessor<number[][]>;
+  private setPendingTransfers: Setter<number[][]>;
+
   constructor(urls: ApisUrls, mqtt: MqttClient) {
     this.urls = urls;
     this.mqtt = mqtt;
 
     [this.cartEntries, this.setCartEntries] = createSignal<CartResponse>();
+    [this.pendingTransfers, this.setPendingTransfers] = createSignal<
+      number[][]
+    >([], {
+      equals: false,
+    });
 
     this.mqtt.emitter.on("refresh", this.refreshCart.bind(this));
+    this.mqtt.emitter.on("transfer", this.addPendingTransfer.bind(this));
   }
 
   close() {
     this.mqtt.emitter.off("refresh", this.refreshCart.bind(this));
+    this.mqtt.emitter.off("transfer", this.addPendingTransfer.bind(this));
+  }
+
+  private addPendingTransfer(payload: object | null) {
+    const data = payload as { badgeIds: number[] };
+
+    let pendingTransfers = this.pendingTransfers();
+    pendingTransfers.push(data.badgeIds);
+    this.setPendingTransfers(pendingTransfers);
+  }
+
+  public getNextTransfer(): number[] | undefined {
+    let pendingTransfers = this.pendingTransfers();
+    const nextTransfer = pendingTransfers.shift();
+    this.setPendingTransfers(pendingTransfers);
+    return nextTransfer;
   }
 
   private async makeRequest<T>(
@@ -215,6 +240,30 @@ export class CartManager {
     );
 
     return await this.makeRequest(url);
+  }
+
+  public async transfer(terminal_id: number): Promise<FallibleRequest<void>> {
+    if (!this.cartEntries()?.result) {
+      return { success: true } as FallibleRequest<void>;
+    }
+
+    let url = new URL(
+      this.urls.onsite_admin_transfer_cart,
+      window.location.href
+    );
+    url.searchParams.append("terminal_id", terminal_id.toString());
+    this.cartEntries()?.result?.forEach((badge) => {
+      url.searchParams.append("badge_id", badge.id.toString());
+    });
+
+    const resp = await this.makeRequest(url);
+    if (!resp.success) {
+      return resp;
+    }
+
+    await this.clearCart();
+
+    return { success: true } as FallibleRequest<void>;
   }
 }
 

--- a/registration/frontend/src/admin/cart/components/Cart.tsx
+++ b/registration/frontend/src/admin/cart/components/Cart.tsx
@@ -28,6 +28,9 @@ export const Cart: Component<{
   });
 
   const anythingLoading = () => refresh.loading || clearing() || remove.loading;
+  const canTransfer = () =>
+    !anythingLoading() &&
+    (props.cartManager.cartEntries()?.result?.length ?? 0) > 0;
 
   createShortcut(["Alt", "R"], () => {
     if (anythingLoading()) return;
@@ -56,6 +59,29 @@ export const Cart: Component<{
 
           <div class="column is-narrow">
             <div class="buttons">
+              <Show when={props.cartManager.pendingTransfers().length > 0}>
+                <button
+                  class="button is-light is-small"
+                  onClick={async (ev) => {
+                    ev.preventDefault();
+
+                    const transfer = props.cartManager.getNextTransfer();
+                    if (!transfer) return;
+
+                    setClearing(true);
+                    await props.cartManager.clearCart();
+                    for (let i = 0; i < transfer.length; i += 1) {
+                      await props.cartManager.addCartId(transfer[i]);
+                    }
+                    setClearing(false);
+                  }}
+                >
+                  <span class="icon">
+                    <i class="fa-solid fa-satellite-dish"></i>
+                  </span>
+                </button>
+              </Show>
+
               <button
                 class="button is-primary is-small"
                 classList={{ "is-loading": refresh.loading }}
@@ -67,6 +93,46 @@ export const Cart: Component<{
                   <i class="fas fa-sync"></i>
                 </span>
               </button>
+
+              <div
+                class="dropdown"
+                classList={{ "is-hoverable": canTransfer() }}
+              >
+                <div class="dropdown-trigger">
+                  <button
+                    class="button is-link is-small"
+                    disabled={!canTransfer()}
+                  >
+                    <span>Transfer</span>
+                    <span class="icon is-small">
+                      <i class="fas fa-angle-down"></i>
+                    </span>
+                  </button>
+                </div>
+                <div class="dropdown-menu">
+                  <div class="dropdown-content">
+                    {APIS_CONFIG.terminals.available
+                      .filter(
+                        (terminal) =>
+                          terminal.id !== APIS_CONFIG.terminals.selected
+                      )
+                      .map((terminal) => (
+                        <a
+                          href="#"
+                          class="dropdown-item"
+                          onClick={async (ev) => {
+                            ev.preventDefault();
+                            setClearing(true);
+                            await props.cartManager.transfer(terminal.id);
+                            setClearing(false);
+                          }}
+                        >
+                          {terminal.name}
+                        </a>
+                      ))}
+                  </div>
+                </div>
+              </div>
 
               <button
                 class="button is-warning is-small"

--- a/registration/frontend/src/admin/cart/components/Cart.tsx
+++ b/registration/frontend/src/admin/cart/components/Cart.tsx
@@ -123,6 +123,7 @@ export const Cart: Component<{
                           onClick={async (ev) => {
                             ev.preventDefault();
                             setClearing(true);
+                            props.clearSearch();
                             await props.cartManager.transfer(terminal.id);
                             setClearing(false);
                           }}

--- a/registration/frontend/src/admin/mqtt.ts
+++ b/registration/frontend/src/admin/mqtt.ts
@@ -5,13 +5,14 @@ import { Accessor, createSignal, Setter } from "solid-js";
 import { ApisMqttConfig } from "../entrypoints/admin";
 
 export type MqttTopic =
-  | "refresh"
-  | "open"
-  | "notification"
   | "alert"
+  | "authorize_terminal"
+  | "notification"
+  | "open"
+  | "refresh"
   | "scan/id"
   | "scan/shc"
-  | "authorize_terminal";
+  | "transfer";
 
 export type MqttEmitter = Emitter<Record<MqttTopic, object | null>>;
 

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -78,6 +78,7 @@ export interface ApisUrls {
   onsite_admin_cart: string;
   onsite_admin_clear_cart: string;
   onsite_admin_search: string;
+  onsite_admin_transfer_cart: string;
   onsite_admin: string;
   onsite_create_discount: string;
   onsite_print_badges: string;

--- a/registration/urls.py
+++ b/registration/urls.py
@@ -162,6 +162,11 @@ urlpatterns = [
         name="onsite_remove_from_cart",
     ),
     re_path(
+        r"^onsite/admin/cart/transfer/?$",
+        registration.views.onsite_admin.onsite_admin_transfer_cart,
+        name="onsite_admin_transfer_cart",
+    ),
+    re_path(
         r"^onsite/admin/terminal/status/?$",
         registration.views.onsite_admin.set_terminal_status,
         name="terminal_status",


### PR DESCRIPTION
Not sure how useful this one is, but a feature I've thought about for a bit now is the ability to transfer cart contents between stations. This would be helpful if it turns out someone is paying cash at a non-cash station after we've already scanned their ID.

![2025-03-12 17 55 40](https://github.com/user-attachments/assets/03855f18-7566-4423-bea5-101378cfe3d3)
