### PR TITLE
Rework MQTT topic names

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -107,7 +107,7 @@ class FirebaseAdmin(admin.ModelAdmin):
         obj.save()
 
         registration.views.onsite_admin.send_mqtt_message_to_terminal(
-            obj, ["payment", "update", "config"], self.get_provisioning(obj)
+            obj, "payment/update/config", self.get_provisioning(obj)
         )
 
     @staticmethod

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -106,13 +106,9 @@ class FirebaseAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         obj.save()
 
-        data = {
-            "updateConfig": {
-                "config": self.get_provisioning(obj),
-            }
-        }
-
-        registration.views.onsite_admin.send_mqtt_message_to_terminal(obj, data)
+        registration.views.onsite_admin.send_mqtt_message_to_terminal(
+            obj, ["payment", "update", "config"], self.get_provisioning(obj)
+        )
 
     @staticmethod
     def get_provisioning(firebase):

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -144,11 +144,13 @@ class FirebaseAdmin(admin.ModelAdmin):
 
         receipt_token = mqtt.get_receipt_token(obj)
         station_token = mqtt.get_station_token(obj)
+        state_token = mqtt.get_state_token(obj)
 
         context = {
             "qr_svg": self.get_qrcode(provisioning).decode("utf-8"),
             "receipt_token": receipt_token,
             "station_token": station_token,
+            "state_token": state_token,
         }
 
         return render(request, "admin/firebase_qr.html", context)

--- a/registration/admin.py
+++ b/registration/admin.py
@@ -118,7 +118,7 @@ class FirebaseAdmin(admin.ModelAdmin):
     def get_provisioning(firebase):
         current_site = Site.objects.get_current()
         endpoint = "https://{0}".format(current_site.domain)
-        token = mqtt.get_client_token(firebase)
+        token = mqtt.get_payment_token(firebase)
 
         return {
             "terminalName": firebase.name,
@@ -130,8 +130,7 @@ class FirebaseAdmin(admin.ModelAdmin):
             "mqttPort": 443,
             "mqttUsername": token["user"],
             "mqttPassword": token["token"],
-            "mqttTopic": f'{mqtt.get_topic("terminal", firebase.name)}/action',
-            "mqttPublishTopicPrefix": f'{mqtt.get_topic("admin", firebase.name)}',
+            "mqttPrefix": token["root_topic"],
             "squareApplicationId": settings.SQUARE_APPLICATION_ID,
             "squareLocationId": settings.REGISTER_SQUARE_LOCATION,
         }
@@ -146,11 +145,14 @@ class FirebaseAdmin(admin.ModelAdmin):
     def provision_view(self, request, pk):
         obj = Firebase.objects.get(id=pk)
         provisioning = json.dumps(self.get_provisioning(obj))
-        token = mqtt.get_client_token(obj)
+
+        receipt_token = mqtt.get_receipt_token(obj)
+        station_token = mqtt.get_station_token(obj)
 
         context = {
             "qr_svg": self.get_qrcode(provisioning).decode("utf-8"),
-            "token": token,
+            "receipt_token": receipt_token,
+            "station_token": station_token,
         }
 
         return render(request, "admin/firebase_qr.html", context)

--- a/registration/frontend/src/admin/Navbar.tsx
+++ b/registration/frontend/src/admin/Navbar.tsx
@@ -444,7 +444,7 @@ export const Navbar: Component<{
                 userSettings={userSettings}
               />
 
-              <Show when={config.terminals.selected?.features?.print_via_mqtt}>
+              <Show when={!!config.mqtt.auth.print_topic}>
                 <ToggleSetting
                   name="Auto Print After Payment"
                   key="print_after_payment"

--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -155,8 +155,7 @@ export class CartManager {
   public async printBadges(
     ids: number[],
     clearCart: boolean = true,
-    mqttPrint: "station" | "payment" | false = false,
-    mqttPrintTopic: string | undefined = undefined,
+    mqttPrint: boolean = false,
     beforeClearingCart?: () => void,
   ): Promise<FallibleRequest<BadgePrintResponse>> {
     const assignData = await this.makeRequest(this.urls.assign_badge_number, {
@@ -179,25 +178,10 @@ export class CartManager {
 
     const printData = await this.makeRequest<BadgePrintResponse>(url);
 
-    if (printData.success && mqttPrint && mqttPrintTopic) {
+    if (printData.success && mqttPrint) {
       const url = new URL(printData.file, window.location.href);
 
-      if (mqttPrint === "station") {
-        this.mqtt.publishUnprefixedMessage(
-          mqttPrintTopic,
-          JSON.stringify({
-            action: "print",
-            url,
-          }),
-        );
-      } else if (mqttPrint === "payment") {
-        this.mqtt.publishUnprefixedMessage(
-          mqttPrintTopic,
-          JSON.stringify({
-            printUrl: { url: url },
-          }),
-        );
-      }
+      this.mqtt.publishPrintMessage(JSON.stringify({ url }));
 
       if (clearCart) {
         beforeClearingCart?.();

--- a/registration/frontend/src/admin/cart/components/CartActions.tsx
+++ b/registration/frontend/src/admin/cart/components/CartActions.tsx
@@ -66,7 +66,7 @@ export const CartActions: Component<{
       false,
   );
 
-  if (config.terminals.selected?.features?.print_via_mqtt) {
+  if (config.mqtt.auth.print_topic) {
     const autoPrintCheck = createAutoPrintCheck(printableBadgeIds);
 
     createEffect(async () => {
@@ -79,8 +79,7 @@ export const CartActions: Component<{
           setLoading,
           userSettings.userSettings().clear_cart_after_print,
           props.clearSearch,
-          config.terminals.selected?.features.print_via_mqtt || false,
-          config.terminals.selected?.features.mqtt_print_topic,
+          !!config.mqtt.auth.print_topic,
         );
       }
     });
@@ -154,7 +153,7 @@ export const CartActions: Component<{
           </Show>
 
           <Show
-            when={APIS_CONFIG.terminals.selected?.features?.payment_type}
+            when={APIS_CONFIG.terminals.selected?.features?.card}
             fallback={<div class="column"></div>}
           >
             <ActionButton
@@ -211,10 +210,7 @@ export const CartActions: Component<{
                 setLoading,
                 userSettings.userSettings().clear_cart_after_print,
                 props.clearSearch,
-                (!holdingShift &&
-                  config.terminals.selected?.features?.print_via_mqtt) ||
-                  false,
-                config.terminals.selected?.features?.mqtt_print_topic,
+                !holdingShift && !!config.mqtt.auth.print_topic,
               );
             }}
           >
@@ -292,15 +288,13 @@ async function printBadges(
   setLoading: Setter<boolean>,
   clearCart: boolean,
   clearSearch: () => void,
-  mqttPrint: "station" | "payment" | false,
-  mqttPrintTopic: string | undefined,
+  mqttPrint: boolean,
 ) {
   setLoading(true);
   const resp = await manager.printBadges(
     ids,
     clearCart,
     mqttPrint,
-    mqttPrintTopic,
     clearSearch,
   );
   setLoading(false);

--- a/registration/frontend/src/admin/mqtt.tsx
+++ b/registration/frontend/src/admin/mqtt.tsx
@@ -6,14 +6,15 @@ import { Accessor, Setter, createSignal } from "solid-js";
 import { ApisMqttConfig } from "../entrypoints/admin";
 
 export type MqttTopic =
-  | "alert"
-  | "authorize_terminal"
-  | "notification"
-  | "open"
+  | "authorize/square"
+  | "notify/alert"
+  | "notify/info"
+  | "notify/payment"
+  | "notify/scan/id"
+  | "notify/scan/shc"
+  | "notify/scan/url"
+  | "presence"
   | "refresh"
-  | "scan/id"
-  | "scan/shc"
-  | "payment_notification"
   | "transfer";
 
 export type MqttEmitter = Emitter<Record<MqttTopic, object | null>>;
@@ -23,6 +24,15 @@ const KNOWN_MESSAGES: Record<string, [string, string]> = {
   payment_cancelled: ["Payment cancelled", "is-warning"],
   payment_failed: ["Payment failed", "is-danger"],
   payment_completed: ["Payment completed", "is-success"],
+};
+
+const getDeviceId = (): string => {
+  const existingValue = localStorage.getItem("device-id");
+  if (existingValue) return existingValue;
+
+  const newValue = window.crypto.randomUUID();
+  localStorage.setItem("device-id", newValue);
+  return newValue;
 };
 
 export default class MqttClient {
@@ -50,7 +60,7 @@ export default class MqttClient {
     this.client = mqtt.connect(config.broker, {
       username: config.auth.user,
       password: config.auth.token,
-      clientId: `admin-${config.auth.user}`,
+      clientId: `web-${config.auth.user}-${getDeviceId()}`,
       clean: false,
       protocolVersion: 5,
       timerVariant: "native",
@@ -66,10 +76,7 @@ export default class MqttClient {
         if (err) {
           console.error(`MQTT subscription failed: ${err}`);
         } else {
-          this.client?.publish(
-            this.getPrefixedTopic("admin_presence"),
-            JSON.stringify(":3"),
-          );
+          this.publishMessage("web/presence", JSON.stringify(getDeviceId()));
         }
       });
     });
@@ -83,15 +90,15 @@ export default class MqttClient {
       console.debug("Reconnecting to MQTT");
     });
 
+    const webPrefix = `${config.auth.root_topic}/web/`;
+
     this.client.on("message", (topic, message) => {
       let data = message.toString();
       console.debug("MQTT message", topic, data);
 
       let strippedTopic: MqttTopic;
-      if (topic.startsWith(config.auth.base_topic)) {
-        strippedTopic = topic.slice(
-          config.auth.base_topic.length + 1,
-        ) as MqttTopic;
+      if (topic.startsWith(webPrefix)) {
+        strippedTopic = topic.slice(webPrefix.length) as MqttTopic;
       } else {
         console.warn(`Got topic with unexpected prefix: ${topic}`);
         return;
@@ -103,22 +110,17 @@ export default class MqttClient {
       } catch (err) {}
 
       switch (strippedTopic) {
-        case "notification":
-          if (payload?.["text"]) {
-            sendNotification(payload["text"]);
-          }
-          break;
-        case "alert":
-          if (payload?.["text"]) {
-            alert(payload["text"]);
-          }
-          break;
-        case "authorize_terminal":
+        case "authorize/square":
           if (payload?.["url"] && payload?.["state"]) {
             document.cookie = `square_oauth_state=${payload["state"]}; path=/`;
             window.open(payload["url"], "square_oauth");
           }
-        case "payment_notification":
+        case "notify/alert":
+          if (payload?.["text"]) {
+            alert(payload["text"]);
+          }
+          break;
+        case "notify/payment":
           const message =
             KNOWN_MESSAGES[payload as keyof typeof KNOWN_MESSAGES];
           const [text, className] = (message && [message[0], message[1]]) || [
@@ -136,6 +138,21 @@ export default class MqttClient {
               {text}
             </Toast>
           ));
+          break;
+        case "presence":
+          if (payload !== getDeviceId()) {
+            toaster.show((props) => (
+              <Toast
+                as="div"
+                toastId={props.toastId}
+                class={`notification toast is-warning`}
+                onClick={() => toaster.dismiss(props.toastId)}
+              >
+                Another connection has been opened to this station
+              </Toast>
+            ));
+          }
+          break;
         default:
           this.emitter.emit(strippedTopic, payload);
           break;
@@ -147,30 +164,18 @@ export default class MqttClient {
     this.client?.end();
   }
 
-  public publishUnprefixedMessage(topic: string, payload: string) {
-    this.client?.publish(topic, payload);
-  }
-
   public publishMessage(topic: string, payload: string) {
     this.client?.publish(this.getPrefixedTopic(topic), payload);
   }
 
   public publishPrintMessage(payload: string) {
     this.client?.publish(
-      this.config.auth.print_topic || this.getPrefixedTopic("action"),
+      this.config.auth.print_topic || this.getPrefixedTopic("station/print"),
       payload,
     );
   }
 
   private getPrefixedTopic(topic: string): string {
-    return `${this.config.auth.base_topic}/${topic}`;
-  }
-}
-
-function sendNotification(message: string) {
-  if (Notification.permission === "granted") {
-    return new Notification(message);
-  } else {
-    alert(message);
+    return `${this.config.auth.root_topic}/${topic}`;
   }
 }

--- a/registration/frontend/src/admin/scan/components/ScanPanel.tsx
+++ b/registration/frontend/src/admin/scan/components/ScanPanel.tsx
@@ -69,16 +69,7 @@ export const ScanPanel: Component<{
   createEffect(() => {
     const emitter = props.emitter;
 
-    emitter.on("open", (payload: object | null) => {
-      if (payload && "url" in payload) {
-        const url = payload["url"] as string;
-        setStore("url", url);
-      } else {
-        console.error("Open command missing URL");
-      }
-    });
-
-    emitter.on("scan/id", (payload: object | null) => {
+    emitter.on("notify/scan/id", (payload: object | null) => {
       if (payload) {
         setStore("id", payload);
       } else {
@@ -86,11 +77,20 @@ export const ScanPanel: Component<{
       }
     });
 
-    emitter.on("scan/shc", (payload: object | null) => {
+    emitter.on("notify/scan/shc", (payload: object | null) => {
       if (payload) {
         setStore("shc", payload);
       } else {
         console.error("Missing SHC scan payload");
+      }
+    });
+
+    emitter.on("notify/scan/url", (payload: object | null) => {
+      if (payload && "url" in payload) {
+        const url = payload["url"] as string;
+        setStore("url", url);
+      } else {
+        console.error("Open command missing URL");
       }
     });
   });

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -56,7 +56,7 @@ export interface ApisMqttConfig {
 export interface ApisMqttAuth {
   user: string;
   token: string;
-  base_topic: string;
+  root_topic: string;
   print_topic?: string;
 }
 
@@ -110,11 +110,9 @@ export interface ApisSelectedTerminal {
 }
 
 export interface ApisTerminalFeatures {
-  print_via_mqtt: "station" | "payment" | false;
-  mqtt_print_topic: string | undefined;
-  square_terminal: boolean;
-  payment_type?: "mqtt-app" | "square-terminal";
+  card: boolean;
   cashdrawer: boolean;
+  square_terminal: boolean;
 }
 
 export interface ApisTerminal {

--- a/registration/mqtt.py
+++ b/registration/mqtt.py
@@ -40,8 +40,8 @@ def get_payment_token(firebase: Firebase) -> dict:
     sub = get_topic("payment", "#", name=str(firebase.name))
 
     pub = [
-        get_topic("station", "notify", "alert", name=str(firebase.name)),
-        get_topic("station", "notify", "payment", name=str(firebase.name)),
+        get_topic("web", "notify", "alert", name=str(firebase.name)),
+        get_topic("web", "notify", "payment", name=str(firebase.name)),
     ]
 
     user = format_topic(str(firebase.name))
@@ -88,9 +88,10 @@ def get_onsite_admin_token(firebase: Firebase) -> dict:
 
 def get_receipt_token(firebase: Firebase) -> dict:
     sub = get_topic("receipt", "#", name=str(firebase.name))
+    pub = get_topic("web", "notify", "alert", name=str(firebase.name))
 
     user = format_topic(str(firebase.name))
-    token = get_token(user, subs=[sub], publ=[], exp=60 * 60 * 24 * 7)
+    token = get_token(user, subs=[sub], publ=[pub], exp=60 * 60 * 24 * 7)
 
     return {
         "user": user,
@@ -100,10 +101,7 @@ def get_receipt_token(firebase: Firebase) -> dict:
 
 def get_station_token(firebase: Firebase) -> dict:
     sub = get_topic("station", "#", name=str(firebase.name))
-
-    pub = [
-        get_topic("web", "notify", "#", name=str(firebase.name))
-    ]
+    pub = [get_topic("web", "notify", "#", name=str(firebase.name))]
 
     user = format_topic(str(firebase.name))
     token = get_token(user, subs=[sub], publ=pub, exp=60 * 60 * 24 * 7)
@@ -113,6 +111,15 @@ def get_station_token(firebase: Firebase) -> dict:
         "token": token,
         "base_topic": get_topic("station", name=str(firebase.name)),
     }
+
+
+def get_state_token(firebase: Firebase) -> dict:
+    sub = get_topic("payment", "state", name=str(firebase.name))
+
+    user = format_topic(str(firebase.name))
+    token = get_token(user, subs=[sub], publ=[])
+
+    return {"user": user, "token": token}
 
 
 def get_token(sub, exp=None, subs=None, publ=None) -> str:

--- a/registration/mqtt.py
+++ b/registration/mqtt.py
@@ -62,18 +62,18 @@ def get_onsite_admin_token(firebase: Firebase) -> dict:
         get_topic("station/#", name=str(firebase.name)),
     ]
 
-    print_firebase = firebase
-    if firebase.print_via_mqtt and firebase.print_via_mqtt.id != firebase.id:
+    print_topic = None
+    if firebase.print_via_mqtt:
         print_firebase = firebase.print_via_mqtt
 
-    print_device = "station"
-    if firebase.print_via_payment:
-        print_device = "payment"
+        print_device = "station"
+        if firebase.print_via_payment:
+            print_device = "payment"
 
-    print_topic = get_topic(print_device, "print", name=str(print_firebase.name))
+        print_topic = get_topic(print_device, "print", name=str(print_firebase.name))
 
-    if print_firebase.id != firebase.id:
-        pub.append(print_topic)
+        if print_firebase.id != firebase.id:
+            pub.append(print_topic)
 
     user = format_topic(str(firebase.name))
     token = get_token(user, subs=[sub], publ=pub, exp=60 * 60 * 24)

--- a/registration/mqtt.py
+++ b/registration/mqtt.py
@@ -37,11 +37,11 @@ def get_topic(*args: str, name: str) -> str:
 
 
 def get_payment_token(firebase: Firebase) -> dict:
-    sub = get_topic("payment", "#", name=str(firebase.name))
+    sub = get_topic("payment/#", name=str(firebase.name))
 
     pub = [
-        get_topic("web", "notify", "alert", name=str(firebase.name)),
-        get_topic("web", "notify", "payment", name=str(firebase.name)),
+        get_topic("web/notify/alert", name=str(firebase.name)),
+        get_topic("web/notify/payment", name=str(firebase.name)),
     ]
 
     user = format_topic(str(firebase.name))
@@ -55,11 +55,11 @@ def get_payment_token(firebase: Firebase) -> dict:
 
 
 def get_onsite_admin_token(firebase: Firebase) -> dict:
-    sub = get_topic("web", "#", name=str(firebase.name))
+    sub = get_topic("web/#", name=str(firebase.name))
 
     pub = [
-        get_topic("payment", "#", name=str(firebase.name)),
-        get_topic("station", "#", name=str(firebase.name)),
+        get_topic("payment/#", name=str(firebase.name)),
+        get_topic("station/#", name=str(firebase.name)),
     ]
 
     print_firebase = firebase
@@ -72,7 +72,7 @@ def get_onsite_admin_token(firebase: Firebase) -> dict:
 
     print_topic = get_topic(print_device, "print", name=str(print_firebase.name))
 
-    if print_device != "station" or print_firebase.id != firebase.id:
+    if print_firebase.id != firebase.id:
         pub.append(print_topic)
 
     user = format_topic(str(firebase.name))
@@ -87,8 +87,8 @@ def get_onsite_admin_token(firebase: Firebase) -> dict:
 
 
 def get_receipt_token(firebase: Firebase) -> dict:
-    sub = get_topic("receipt", "#", name=str(firebase.name))
-    pub = get_topic("web", "notify", "alert", name=str(firebase.name))
+    sub = get_topic("receipt/#", name=str(firebase.name))
+    pub = get_topic("web/notify/alert", name=str(firebase.name))
 
     user = format_topic(str(firebase.name))
     token = get_token(user, subs=[sub], publ=[pub], exp=60 * 60 * 24 * 7)
@@ -100,8 +100,8 @@ def get_receipt_token(firebase: Firebase) -> dict:
 
 
 def get_station_token(firebase: Firebase) -> dict:
-    sub = get_topic("station", "#", name=str(firebase.name))
-    pub = [get_topic("web", "notify", "#", name=str(firebase.name))]
+    sub = get_topic("station/#", name=str(firebase.name))
+    pub = [get_topic("web/notify/#", name=str(firebase.name))]
 
     user = format_topic(str(firebase.name))
     token = get_token(user, subs=[sub], publ=pub, exp=60 * 60 * 24 * 7)
@@ -114,7 +114,7 @@ def get_station_token(firebase: Firebase) -> dict:
 
 
 def get_state_token(firebase: Firebase) -> dict:
-    sub = get_topic("payment", "state", name=str(firebase.name))
+    sub = get_topic("payment/state", name=str(firebase.name))
 
     user = format_topic(str(firebase.name))
     token = get_token(user, subs=[sub], publ=[])
@@ -149,28 +149,39 @@ def format_topic(topic: str, allow_wildcard: bool = False) -> str:
     Removes characters that shouldn't be in an MQTT topic field, namely:
 
     - Can't start with $ (reserved for system topics)
-    - Can't contain # or + (wildcards)
-    - Can't contain / (separator)
+    - Can't contain # or + (wildcards) unless specifically permitted
     - All-lowercase, remove spaces (recommended style)
     """
+
+    if "/" in topic:
+        return "/".join(
+            [
+                format_topic(segment, allow_wildcard=allow_wildcard)
+                for segment in topic.split("/")
+            ]
+        )
 
     if allow_wildcard and topic in ("+", "#"):
         return topic
 
     topic = FORMAT_TOPIC_SYS_RE.sub("", topic)
     topic = FORMAT_TOPIC_WILDCARD_RE.sub("", topic)
+
+    if len(topic) == 0:
+        raise ValueError("Each topic segment must have value")
+
     return topic.lower()
 
 
 def send_mqtt_message(topic: str, payload: dict = {}, retain: bool = False):
     payload_json = json.dumps(payload, cls=JSONDecimalEncoder)
-
-    logger.info(f"Sending MQTT message: {topic} ({payload_json})")
+    logger.debug(f"Sending MQTT message: {topic} ({payload_json})")
 
     auth = {
-        "username": "apis_server",
-        "password": get_token("apis_server", publ=[topic], exp=30),
+        "username": "apis-server",
+        "password": get_token("apis-server", publ=[topic], exp=30),
     }
+
     tls = settings.MQTT_BROKER.get("tls")
 
     mqtt_publish.single(

--- a/registration/mqtt.py
+++ b/registration/mqtt.py
@@ -1,25 +1,22 @@
 import base64
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 import json
 import logging
 import re
-from datetime import datetime, timezone
-from decimal import Decimal
 
-import jwt
 from django.conf import settings
-from paho.mqtt import publish as mqtt
+import jwt
+from paho.mqtt import publish as mqtt_publish
+
+from registration.models import Firebase
 
 FORMAT_TOPIC_SYS_RE = re.compile(r"^\$")
 FORMAT_TOPIC_WILDCARD_RE = re.compile(r"[\#\+ /]")
 
-logger = logging.getLogger(__name__)
-
 BASE_TOPIC = "apis"
-TOPICS = [
-    "receipts",
-    "admin",
-    "terminal",
-]
+
+logger = logging.getLogger(__name__)
 
 
 class JSONDecimalEncoder(json.JSONEncoder):
@@ -29,46 +26,101 @@ class JSONDecimalEncoder(json.JSONEncoder):
         return o
 
 
-def get_topic(topic, target=None):
-    if target:
-        return f"{BASE_TOPIC}/{topic}/{format_topic(target)}"
-    return f"{BASE_TOPIC}/{topic}"
+def get_topic(*args: str, name: str) -> str:
+    """Build a topic for a given device.
+
+    Wildcard segments are allowed."""
+    segments = [BASE_TOPIC, format_topic(name)] + [
+        format_topic(segment, allow_wildcard=True) for segment in args
+    ]
+    return "/".join(segments)
 
 
-def get_client_token(firebase):
-    user = format_topic(firebase.name)
-    topics = [f"{get_topic(t)}/{user}/#" for t in TOPICS]
-    token = get_token(user, subs=topics, publ=topics)
+def get_payment_token(firebase: Firebase) -> dict:
+    sub = get_topic("payment", "#", name=str(firebase.name))
+
+    pub = [
+        get_topic("station", "notify", "alert", name=str(firebase.name)),
+        get_topic("station", "notify", "payment", name=str(firebase.name)),
+    ]
+
+    user = format_topic(str(firebase.name))
+    token = get_token(user, subs=[sub], publ=pub, exp=60 * 60 * 24 * 7)
+
     return {
         "user": user,
         "token": token,
+        "root_topic": get_topic(name=str(firebase.name)),
     }
 
 
-def get_onsite_admin_token(firebase):
-    user = format_topic(firebase.name)
-    base_topic = f"{get_topic('admin')}/{user}"
-    topics = [f"{base_topic}/#"]
-    print_topic = None
+def get_onsite_admin_token(firebase: Firebase) -> dict:
+    sub = get_topic("web", "#", name=str(firebase.name))
+
+    pub = [
+        get_topic("payment", "#", name=str(firebase.name)),
+        get_topic("station", "#", name=str(firebase.name)),
+    ]
+
+    print_firebase = firebase
     if firebase.print_via_mqtt and firebase.print_via_mqtt.id != firebase.id:
-        print_topic = f"{get_topic('admin')}/{format_topic(firebase.print_via_mqtt.name)}/action"
-        topics.append(print_topic)
-    if firebase.print_via_mqtt and firebase.print_via_payment:
-        print_topic = f"{get_topic('terminal')}/{format_topic(firebase.print_via_mqtt.name)}/action"
-        topics.append(print_topic)
-    token = get_token(user, subs=topics, publ=topics)
+        print_firebase = firebase.print_via_mqtt
+
+    print_device = "station"
+    if firebase.print_via_payment:
+        print_device = "payment"
+
+    print_topic = get_topic(print_device, "print", name=str(print_firebase.name))
+
+    if print_device != "station" or print_firebase.id != firebase.id:
+        pub.append(print_topic)
+
+    user = format_topic(str(firebase.name))
+    token = get_token(user, subs=[sub], publ=pub, exp=60 * 60 * 24)
+
     return {
         "user": user,
         "token": token,
-        "base_topic": base_topic,
+        "root_topic": get_topic(name=str(firebase.name)),
         "print_topic": print_topic,
     }
 
 
-def get_token(sub, exp=None, subs=None, publ=None):
+def get_receipt_token(firebase: Firebase) -> dict:
+    sub = get_topic("receipt", "#", name=str(firebase.name))
+
+    user = format_topic(str(firebase.name))
+    token = get_token(user, subs=[sub], publ=[], exp=60 * 60 * 24 * 7)
+
+    return {
+        "user": user,
+        "token": token,
+    }
+
+
+def get_station_token(firebase: Firebase) -> dict:
+    sub = get_topic("station", "#", name=str(firebase.name))
+
+    pub = [
+        get_topic("web", "notify", "#", name=str(firebase.name))
+    ]
+
+    user = format_topic(str(firebase.name))
+    token = get_token(user, subs=[sub], publ=pub, exp=60 * 60 * 24 * 7)
+
+    return {
+        "user": user,
+        "token": token,
+        "base_topic": get_topic("station", name=str(firebase.name)),
+    }
+
+
+def get_token(sub, exp=None, subs=None, publ=None) -> str:
     if exp is None:
         # Never expires
         exp = 2**31 - 1
+    else:
+        exp = datetime.now(tz=timezone.utc) + timedelta(seconds=exp)
 
     claims = {
         "sub": sub,
@@ -85,7 +137,7 @@ def get_token(sub, exp=None, subs=None, publ=None):
     )
 
 
-def format_topic(topic):
+def format_topic(topic: str, allow_wildcard: bool = False) -> str:
     """
     Removes characters that shouldn't be in an MQTT topic field, namely:
 
@@ -95,21 +147,26 @@ def format_topic(topic):
     - All-lowercase, remove spaces (recommended style)
     """
 
+    if allow_wildcard and topic in ("+", "#"):
+        return topic
+
     topic = FORMAT_TOPIC_SYS_RE.sub("", topic)
     topic = FORMAT_TOPIC_WILDCARD_RE.sub("", topic)
     return topic.lower()
 
 
-def send_mqtt_message(topic, payload={}, retain=False):
+def send_mqtt_message(topic: str, payload: dict = {}, retain: bool = False):
     payload_json = json.dumps(payload, cls=JSONDecimalEncoder)
 
     logger.info(f"Sending MQTT message: {topic} ({payload_json})")
+
     auth = {
         "username": "apis_server",
-        "password": get_token("apis_server", publ=[topic]),
+        "password": get_token("apis_server", publ=[topic], exp=30),
     }
     tls = settings.MQTT_BROKER.get("tls")
-    mqtt.single(
+
+    mqtt_publish.single(
         topic,
         payload_json,
         retain=retain,

--- a/registration/templates/admin/firebase_qr.html
+++ b/registration/templates/admin/firebase_qr.html
@@ -4,25 +4,25 @@
 {% block content %}
 {% if request.user.is_superuser %}
 <br>
+  <h2>Setup payment terminal</h2>
   {{ qr_svg | safe }}<br><br>
 
-  <h2>Setup payment terminal</h2>
-  <p>Press the clock on the payment terminal you wish to provision, and press "Provision Settings".</p>
+  <h2>Station interface credentials</h2>
+  <pre style="overflow: hidden">
+[connections.credentials]
+username = "{{station_token.user}}"
+password = "{{station_token.token}}"
+  </pre>
 
-  <h2>Client worker (APIS-Receipts)</h2>
-  <p>Use this credential in the <code>settings.py</code> file to configure access to receipt printers and barcode scanners:</p>
+  <h2>Receipt printer credentials</h2>
   <pre style="overflow: hidden">
 MQTT_LOGIN = {
-    "username": "{{token.user}}",
-    "password": "{{token.token}}",
+    "username": "{{receipt_token.user}}",
+    "password": "{{receipt_token.token}}",
 }
   </pre>
+
   <input type="button" onclick="javascript:window.history.back();" class="cancel" value="Go Back"/>
-
-<script>
-
-</script>
-
 {% else %}
   <h1>Sorry</h1>
   <p>You must be a superuser to access this URL.</p>

--- a/registration/templates/admin/firebase_qr.html
+++ b/registration/templates/admin/firebase_qr.html
@@ -22,6 +22,14 @@ MQTT_LOGIN = {
 }
   </pre>
 
+  <h2>State observer credentials</h2>
+  <pre style="overflow: hidden">
+{
+  "username": "{{state_token.user}}"
+  "password": "{{state_token.token}}"
+}
+  </pre>
+
   <input type="button" onclick="javascript:window.history.back();" class="cancel" value="Go Back"/>
 {% else %}
   <h1>Sorry</h1>

--- a/registration/tests/test_admin_firebase.py
+++ b/registration/tests/test_admin_firebase.py
@@ -33,7 +33,7 @@ class TestFirebaseAdmin(TestCase):
 
         current_site = Site.objects.get_current()
         endpoint = "https://{0}".format(current_site.domain)
-        token = mqtt.get_client_token(firebase)
+        token = mqtt.get_payment_token(firebase)
 
         expected_result = {
             "terminalName": firebase.name,
@@ -45,8 +45,7 @@ class TestFirebaseAdmin(TestCase):
             "mqttPort": 443,
             "mqttUsername": token["user"],
             "mqttPassword": token["token"],
-            "mqttTopic": f'{mqtt.get_topic("terminal", firebase.name)}/action',
-            "mqttPublishTopicPrefix": f'{mqtt.get_topic("admin", firebase.name)}',
+            "mqttPrefix": "apis/blue",
             "squareApplicationId": settings.SQUARE_APPLICATION_ID,
             "squareLocationId": settings.REGISTER_SQUARE_LOCATION,
         }
@@ -95,7 +94,7 @@ class TestFirebaseAdmin(TestCase):
             b"<?xml version='1.0' encoding='UTF-8'?>\n<svg ",
             response.content,
         )
-        self.assertIn(b'height="117mm"', response.content)
+        self.assertIn(b'height="109mm"', response.content)
 
     def test_provision_page_normal_user(self):
         self.assertTrue(self.client.login(username="john", password="john"))

--- a/registration/tests/test_mqtt.py
+++ b/registration/tests/test_mqtt.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+from registration.mqtt import format_topic, get_topic
+
+
+class TestMqtt(TestCase):
+    def test_format_topic(self):
+        test_cases = [
+            ("$hello", "hello"),
+            ("hello+", "hello"),
+            ("hello/world", "hello/world"),
+            ("hello / world", "hello/world"),
+        ]
+
+        for test_case, expected in test_cases:
+            self.assertEqual(format_topic(test_case), expected)
+
+        with self.assertRaises(ValueError):
+            format_topic("test/#")
+
+        self.assertEqual(format_topic("test/#", allow_wildcard=True), "test/#")
+
+    def test_get_topic(self):
+        test_cases = [
+            (["$testing/1/2/3"], "apis/name/testing/1/2/3"),
+            (["hello", "multiple"], "apis/name/hello/multiple"),
+        ]
+
+        for test_case, expected in test_cases:
+            self.assertEqual(get_topic(*test_case, name="name"), expected)

--- a/registration/tests/test_onsite.py
+++ b/registration/tests/test_onsite.py
@@ -317,7 +317,7 @@ class TestOnsiteAdmin(OnsiteBaseTestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(mock_send_mqtt_single.call_count, 2)
+        self.assertEqual(mock_send_mqtt_single.call_count, 1)
 
     @patch("registration.mqtt.send_mqtt_message")
     def test_onsite_set_invalid_terminal_status(self, mock_send_mqtt_message):

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 TWOPLACES = Decimal(10) ** -2
 
 
-def get_active_terminal(request):
+def get_active_terminal(request) -> Optional[Firebase]:
     term_id = request.session.get("terminal")
     if term_id:
         try:
@@ -110,31 +110,18 @@ def onsite_admin(request):
             errors.append({"type": "danger", "text": "Invalid terminal specified"})
 
     terminal = get_active_terminal(request)
-    mqtt_auth = None
-    if terminal:
-        mqtt_auth = mqtt.get_onsite_admin_token(terminal)
 
+    mqtt_auth = None
     selected_terminal = None
     if terminal:
-        print_via_mqtt = False
-        mqtt_print_topic = None
-        if terminal.print_via_mqtt:
-            if terminal.print_via_payment:
-                print_via_mqtt = "payment"
-                mqtt_print_topic = f"{mqtt.get_topic('terminal')}/{mqtt.format_topic(terminal.print_via_mqtt.name)}/action"
-            else:
-                print_via_mqtt = "station"
-                mqtt_print_topic = f"{mqtt.get_topic('admin')}/{mqtt.format_topic(terminal.print_via_mqtt.name)}/action"
-
+        mqtt_auth = mqtt.get_onsite_admin_token(terminal)
         selected_terminal = {
             "id": terminal.id,
             "features": {
                 "square_terminal": terminal.square_terminal_id is not None,
-                "print_via_mqtt": print_via_mqtt,
-                "mqtt_print_topic": mqtt_print_topic,
-                "payment_type": terminal.payment_type,
+                "card": terminal.payment_type is not None,
                 "cashdrawer": terminal.cashdrawer,
-            }
+            },
         }
 
     context = {
@@ -281,19 +268,16 @@ def onsite_admin_search(request):
 def update_terminal_status(request, status: str) -> JsonResponse:
     active = get_terminal_from_request(request)
     if not active:
-        return JsonResponse({"success": False, "reason": "No terminal associated with request"}, status=400)
+        return JsonResponse(
+            {"success": False, "reason": "No terminal associated with request"},
+            status=400,
+        )
 
-    stateCommand = status
-    if stateCommand == "close":
-        stateCommand = "closed"
-    mqtt.send_mqtt_message(f"{mqtt.get_topic('admin', active.name)}/terminal/state", stateCommand)
-
-    if status not in ("close", "open", "ready"):
-        return JsonResponse({"success": True})
-
-    return send_mqtt_message_to_terminal(active, {
-        status: {},
-    })
+    return send_mqtt_message_to_terminal(
+        active,
+        ["payment", "state"],
+        status,
+    )
 
 
 @staff_member_required
@@ -324,7 +308,9 @@ def get_terminal_from_request(request) -> Optional[Firebase]:
     return active
 
 
-def send_mqtt_message_to_terminal(request: Union[HttpRequest, Firebase], data: dict) -> JsonResponse:
+def send_mqtt_message_to_terminal(
+    request: Union[HttpRequest, Firebase], segments: List[str], data={}
+) -> JsonResponse:
     if isinstance(request, Firebase):
         active = request
     else:
@@ -332,8 +318,7 @@ def send_mqtt_message_to_terminal(request: Union[HttpRequest, Firebase], data: d
         if not active:
             return JsonResponse({"sucess": False, "reason": "No terminal associated with request"}, status=400)
 
-    name = active.name
-    topic = f'{mqtt.get_topic("terminal", name)}/action'
+    topic = mqtt.get_topic(*segments, name=str(active.name))
 
     try:
         mqtt.send_mqtt_message(topic, data)
@@ -403,14 +388,17 @@ def enable_payment(request):
             "reason": ", ".join([error["detail"] for error in resp.errors]) if resp.errors else None,
         })
     elif terminal.payment_type == Firebase.MQTT_REGISTER_APP:
-        return send_mqtt_message_to_terminal(terminal, {
-            "processPayment": {
+        return send_mqtt_message_to_terminal(
+            terminal,
+            ["payment", "process"],
+            {
+                "paymentAttemptId": payments.get_idempotency_key(request),
                 "orderId": order_id,
                 "total": int(data["total"] * 100),
                 "reference": data["reference"],
                 "note": render_to_string("registration/customer-note.txt", data),
-            }
-        })
+            },
+        )
     else:
         return JsonResponse({
             "success": False,
@@ -478,10 +466,7 @@ def onsite_print_badges(request):
 
 
 def admin_push_cart_refresh(request):
-    terminal = get_active_terminal(request)
-    if terminal:
-        topic = f"{mqtt.get_topic('admin', terminal.name)}/refresh"
-        mqtt.send_mqtt_message(topic, None)
+    send_mqtt_message_to_terminal(request, ["web", "refresh"])
 
 
 # TODO: update for square SDK data type (fetch txn from square API and store in order.apiData)
@@ -613,8 +598,7 @@ def drawer_status(request):
 @permission_required("order.cash_admin")
 def no_sale(request):
     position = get_active_terminal(request)
-    topic = f"{mqtt.get_topic('receipts', position.name)}/no_sale"
-    mqtt.send_mqtt_message(topic)
+    mqtt.send_mqtt_message(mqtt.get_topic("receipt", "nosale", name=str(position.name)))
 
     return JsonResponse({"success": True})
 
@@ -635,9 +619,9 @@ def print_audit_receipt(request, audit_type, cash_ledger, cashdraw=True):
         "cashdraw": cashdraw,
     }
 
-    topic = f"{mqtt.get_topic('receipts', position.name)}/audit_slip"
-
-    mqtt.send_mqtt_message(topic, payload)
+    mqtt.send_mqtt_message(
+        mqtt.get_topic("receipt", "auditslip", name=str(position.name)), payload
+    )
 
 
 def cash_audit_action(request, action):
@@ -771,11 +755,10 @@ def complete_cash_transaction(request):
 
     payload = cash_receipt_payload(order, tendered, total)
 
-    term = request.session.get("terminal", None)
-    active = Firebase.objects.get(id=term)
-    topic = f"{mqtt.get_topic('receipts', active.name)}/print_cash"
-
-    mqtt.send_mqtt_message(topic, payload)
+    terminal = get_active_terminal(request)
+    mqtt.send_mqtt_message(
+        mqtt.get_topic("receipt", "print/cash", name=str(terminal.name)), payload
+    )
 
     return JsonResponse({"success": True})
 
@@ -1005,9 +988,9 @@ def onsite_admin_cart(request):
     data = build_result(cart)
 
     terminal_data = {
-        "updateCart": {
-            "cart": {
-                "badges": list(map(lambda badge: {
+        "badges": list(
+            map(
+                lambda badge: {
                     "id": badge["id"],
                     "firstName": badge["firstName"],
                     "lastName": badge["lastName"],
@@ -1017,17 +1000,18 @@ def onsite_admin_cart(request):
                         "price": str(badge["level_subtotal"]),
                     },
                     "discountedPrice": str(badge["level_total"]),
-                }, data["result"])),
-                "charityDonation": str(data["charityDonation"]),
-                "organizationDonation": str(data["orgDonation"]),
-                "totalDiscount": str(data["total_discount"]),
-                "total": str(data["total"]),
-                "paid": str(data["paid"]),
-            }
-        }
+                },
+                data["result"],
+            )
+        ),
+        "charityDonation": str(data["charityDonation"]),
+        "organizationDonation": str(data["orgDonation"]),
+        "totalDiscount": str(data["total_discount"]),
+        "total": str(data["total"]),
+        "paid": str(data["paid"]),
     }
 
-    send_mqtt_message_to_terminal(request, terminal_data)
+    send_mqtt_message_to_terminal(request, ["payment", "cart", "update"], terminal_data)
 
     return JsonResponse(data)
 
@@ -1096,7 +1080,7 @@ def onsite_remove_from_cart(request):
 @staff_member_required
 def onsite_admin_clear_cart(request):
     request.session["cart"] = []
-    send_mqtt_message_to_terminal(request, {"clearCart": {}})
+    send_mqtt_message_to_terminal(request, ["payment", "cart", "clear"])
     return JsonResponse({"success": True, "cart": []})
 
 
@@ -1107,10 +1091,13 @@ def onsite_admin_transfer_cart(request):
 
     firebase = Firebase.objects.get(id=terminal_id)
 
-    topic = f'{mqtt.get_topic("admin", firebase.name)}/transfer'
-    mqtt.send_mqtt_message(topic, {
-        "badgeIds": [int(badge_id) for badge_id in badge_ids],
-    })
+    topic = mqtt.get_topic("web", "transfer", name=str(firebase.name))
+    mqtt.send_mqtt_message(
+        topic,
+        {
+            "badgeIds": [int(badge_id) for badge_id in badge_ids],
+        },
+    )
 
     return JsonResponse({"success": True})
 
@@ -1213,13 +1200,17 @@ def terminal_square_token(request):
 
     url = f"{base_url}/oauth2/authorize?client_id={settings.SQUARE_APPLICATION_ID}&state={state}&scope={'+'.join(scopes)}"
 
-    topic = f"{mqtt.get_topic('admin', terminal.name)}/authorize_terminal"
-    mqtt.send_mqtt_message(topic, payload={
-        "url": url,
-        "state": state,
-    })
+    send_mqtt_message_to_terminal(
+        terminal,
+        ["web", "authorize", "square"],
+        {
+            "url": url,
+            "state": state,
+        },
+    )
 
     return JsonResponse(True, safe=False)
+
 
 def oauth_square(request):
     url_state = request.GET.get("state")
@@ -1238,12 +1229,14 @@ def oauth_square(request):
     })
 
     if result.is_success():
-        send_mqtt_message_to_terminal(request, {
-            "updateToken": {
+        send_mqtt_message_to_terminal(
+            request,
+            ["payment", "update", "token"],
+            {
                 "accessToken": result.body["access_token"],
-                "refreshToken": result.body["refresh_token"]
-            }
-        })
+                "refreshToken": result.body["refresh_token"],
+            },
+        )
         resp = HttpResponseRedirect(reverse("registration:onsite_admin"))
     else:
         print(result.errors)
@@ -1272,7 +1265,7 @@ def print_receipts(request):
                 return JsonResponse({"success": False, "reason": "Cash order was missing note data"})
 
             payload = cash_receipt_payload(order, note_data["tendered"], order.total)
-            topic = f"{mqtt.get_topic('receipts', terminal.name)}/print_cash"
+            topic = mqtt.get_topic("receipt", "print", "cash", name=str(terminal.name))
             mqtt.send_mqtt_message(topic, payload)
 
         elif order.billingType == Order.CREDIT:

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -275,7 +275,7 @@ def update_terminal_status(request, status: str) -> JsonResponse:
 
     return send_mqtt_message_to_terminal(
         active,
-        ["payment", "state"],
+        "payment/state",
         status,
     )
 
@@ -309,7 +309,7 @@ def get_terminal_from_request(request) -> Optional[Firebase]:
 
 
 def send_mqtt_message_to_terminal(
-    request: Union[HttpRequest, Firebase], segments: List[str], data={}
+    request: Union[HttpRequest, Firebase], topic: str, data={}
 ) -> JsonResponse:
     if isinstance(request, Firebase):
         active = request
@@ -318,7 +318,7 @@ def send_mqtt_message_to_terminal(
         if not active:
             return JsonResponse({"sucess": False, "reason": "No terminal associated with request"}, status=400)
 
-    topic = mqtt.get_topic(*segments, name=str(active.name))
+    topic = mqtt.get_topic(topic, name=str(active.name))
 
     try:
         mqtt.send_mqtt_message(topic, data)
@@ -390,7 +390,7 @@ def enable_payment(request):
     elif terminal.payment_type == Firebase.MQTT_REGISTER_APP:
         return send_mqtt_message_to_terminal(
             terminal,
-            ["payment", "process"],
+            "payment/process",
             {
                 "paymentAttemptId": payments.get_idempotency_key(request),
                 "orderId": order_id,
@@ -466,7 +466,7 @@ def onsite_print_badges(request):
 
 
 def admin_push_cart_refresh(request):
-    send_mqtt_message_to_terminal(request, ["web", "refresh"])
+    send_mqtt_message_to_terminal(request, "web/refresh")
 
 
 # TODO: update for square SDK data type (fetch txn from square API and store in order.apiData)
@@ -598,7 +598,7 @@ def drawer_status(request):
 @permission_required("order.cash_admin")
 def no_sale(request):
     position = get_active_terminal(request)
-    mqtt.send_mqtt_message(mqtt.get_topic("receipt", "nosale", name=str(position.name)))
+    mqtt.send_mqtt_message(mqtt.get_topic("receipt/nosale", name=str(position.name)))
 
     return JsonResponse({"success": True})
 
@@ -620,7 +620,7 @@ def print_audit_receipt(request, audit_type, cash_ledger, cashdraw=True):
     }
 
     mqtt.send_mqtt_message(
-        mqtt.get_topic("receipt", "auditslip", name=str(position.name)), payload
+        mqtt.get_topic("receipt/auditslip", name=str(position.name)), payload
     )
 
 
@@ -757,7 +757,7 @@ def complete_cash_transaction(request):
 
     terminal = get_active_terminal(request)
     mqtt.send_mqtt_message(
-        mqtt.get_topic("receipt", "print/cash", name=str(terminal.name)), payload
+        mqtt.get_topic("receipt/print/cash", name=str(terminal.name)), payload
     )
 
     return JsonResponse({"success": True})
@@ -1011,7 +1011,7 @@ def onsite_admin_cart(request):
         "paid": str(data["paid"]),
     }
 
-    send_mqtt_message_to_terminal(request, ["payment", "cart", "update"], terminal_data)
+    send_mqtt_message_to_terminal(request, "payment/cart/update", terminal_data)
 
     return JsonResponse(data)
 
@@ -1080,7 +1080,7 @@ def onsite_remove_from_cart(request):
 @staff_member_required
 def onsite_admin_clear_cart(request):
     request.session["cart"] = []
-    send_mqtt_message_to_terminal(request, ["payment", "cart", "clear"])
+    send_mqtt_message_to_terminal(request, "payment/cart/clear")
     return JsonResponse({"success": True, "cart": []})
 
 
@@ -1091,7 +1091,7 @@ def onsite_admin_transfer_cart(request):
 
     firebase = Firebase.objects.get(id=terminal_id)
 
-    topic = mqtt.get_topic("web", "transfer", name=str(firebase.name))
+    topic = mqtt.get_topic("web/transfer", name=str(firebase.name))
     mqtt.send_mqtt_message(
         topic,
         {
@@ -1202,7 +1202,7 @@ def terminal_square_token(request):
 
     send_mqtt_message_to_terminal(
         terminal,
-        ["web", "authorize", "square"],
+        "web/authorize/square",
         {
             "url": url,
             "state": state,
@@ -1231,7 +1231,7 @@ def oauth_square(request):
     if result.is_success():
         send_mqtt_message_to_terminal(
             request,
-            ["payment", "update", "token"],
+            "payment/update/token",
             {
                 "accessToken": result.body["access_token"],
                 "refreshToken": result.body["refresh_token"],
@@ -1265,7 +1265,7 @@ def print_receipts(request):
                 return JsonResponse({"success": False, "reason": "Cash order was missing note data"})
 
             payload = cash_receipt_payload(order, note_data["tendered"], order.total)
-            topic = mqtt.get_topic("receipt", "print", "cash", name=str(terminal.name))
+            topic = mqtt.get_topic("receipt/print/cash", name=str(terminal.name))
             mqtt.send_mqtt_message(topic, payload)
 
         elif order.billingType == Order.CREDIT:

--- a/registration/views/printing.py
+++ b/registration/views/printing.py
@@ -163,7 +163,6 @@ def pdfFromGotenberg(request: HttpRequest) -> Union[HttpResponse, JsonResponse]:
             badge.save()
 
         if terminal := data_obj.get("terminal", None):
-            topic = f"{mqtt.get_topic('admin', terminal)}/refresh"
-            mqtt.send_mqtt_message(topic, None)
+            mqtt.send_mqtt_message(mqtt.get_topic("web", "refresh", name=terminal), None)
 
         return http_resp

--- a/registration/views/printing.py
+++ b/registration/views/printing.py
@@ -163,6 +163,6 @@ def pdfFromGotenberg(request: HttpRequest) -> Union[HttpResponse, JsonResponse]:
             badge.save()
 
         if terminal := data_obj.get("terminal", None):
-            mqtt.send_mqtt_message(mqtt.get_topic("web", "refresh", name=terminal), None)
+            mqtt.send_mqtt_message(mqtt.get_topic("web/refresh", name=terminal), None)
 
         return http_resp


### PR DESCRIPTION
The current MQTT topic structure has been getting harder to work with, due to dynamic parts being after fixed parts. This changes the structure of `apis/admin/$name` to `apis/$name/admin` to make it easier to use different topic names. It's also easier to more strictly enforce pub/sub permissions with these names.

While working on these changes, I made a document with all of the topics we use and what should be using them:

## Devices

Name    | Base Topic           | Description
------- | -------------------- | -----------------------------
Payment | `apis/$name/payment` | Payment terminal (iPad)
Receipt | `apis/$name/receipt` | Receipt printer worker
Station | `apis/$name/station` | Onsite admin station computer
Web     | `apis/$name/web`     | Onsite admin web UI

## Payment Topics

Topic                  | Source | Description
---------------------- | ------ | ---------------------------------------------
`cart/clear`           | Web    | Clear cart
`cart/update`          | Web    | Update cart contents
`print`                | Web    | Print badge using local
`process`              | Server | Prompt display of Square payment
`registration/cancel`  | Web    | Cancel display of onsite registration
`registration/display` | Web    | Prompt display of onsite registration
`state`                | Web    | Change terminal state between open and closed
`update/config`        | Server | Update terminal config data
`update/token`         | Server | Update terminal Square token

## Receipt Topics

Topic             | Source | Description
----------------- | ------ | -------------------------
`cashdrawer/open` | Server | Open cash drawer
`print/cash`      | Server | Print cash receipt
`print/credit`    | Server | Print credit card receipt
`auditslip`       | Server | Print audit slip
`nosale`          | Server | Print no sale

## Station Topics

Topic   | Source | Description
------- | ------ | -----------
`print` | Web    | Print badge

## Web Topics

Topic                    | Source   | Description
------------------------ | -------- | -------------------------------------------------
`authorize/square`       | Server   | Prompt for Square authorization for device
`notify/alert`           | Any      | Display a blocking alert message
`notify/payment`         | Payments | Provide information about payment terminal status
`notify/scan/id`         | Station  | Update scan info with ID card
`notify/scan/shc`        | Station  | Update scan info with Smart Health Card
`notify/scan/url`        | Station  | Update scan info with URL
`presence`               | Web      | Notification that web client has connected
`refresh`                | Server   | Trigger automatic cart refresh
`registration/completed` | Server   | Add new registration to cart
`transfer`               | Server   | Incoming cart transfer request
