### PR TITLE
Unify request handling in onsite admin

### DIFF
--- a/registration/frontend/package-lock.json
+++ b/registration/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "esbuild": "^0.27.2",
         "esbuild-plugin-solid": "^0.6.0",
         "esbuild-sass-plugin": "^3.6.0",
+        "ky": "^1.14.3",
         "mitt": "^3.0.1",
         "mqtt": "^5.14.1",
         "solid-js": "^1.9.11"
@@ -2277,6 +2278,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/lodash-es": {

--- a/registration/frontend/package.json
+++ b/registration/frontend/package.json
@@ -10,6 +10,7 @@
     "esbuild": "^0.27.2",
     "esbuild-plugin-solid": "^0.6.0",
     "esbuild-sass-plugin": "^3.6.0",
+    "ky": "^1.14.3",
     "mitt": "^3.0.1",
     "mqtt": "^5.14.1",
     "solid-js": "^1.9.11"

--- a/registration/frontend/src/admin/Navbar.tsx
+++ b/registration/frontend/src/admin/Navbar.tsx
@@ -11,7 +11,8 @@ import {
   useContext,
 } from "solid-js";
 
-import { ApisConfig, CSRF_TOKEN } from "../entrypoints/admin";
+import { ApisConfig } from "../entrypoints/admin";
+import { FallibleRequest, api } from "./api";
 import { ConfigContext } from "./providers/config-provider";
 import {
   UserSettingKey,
@@ -88,28 +89,17 @@ function makeStatusRequestHelper(url: string) {
     status: "open" | "close" | "ready" | "gay" | "blue-light",
   ) {
     let endpoint = new URL(url, window.location.href);
-    endpoint.searchParams.set("status", status);
 
-    const resp = await fetch(endpoint, {
-      headers: {
-        "x-csrftoken": CSRF_TOKEN,
-      },
-    });
-    const data = await resp.json();
-
-    return data;
+    return await api
+      .post(endpoint, {
+        searchParams: { status: status },
+      })
+      .json();
   };
 }
 
 async function makeSimpleRequest(url: string) {
-  const resp = await fetch(url, {
-    headers: {
-      "x-csrftoken": CSRF_TOKEN,
-    },
-  });
-  const data = await resp.json();
-
-  return data;
+  return await api.get(url).json();
 }
 
 async function amountRequest(url: string, message: string) {
@@ -127,19 +117,16 @@ async function amountRequest(url: string, message: string) {
   let formData = new FormData();
   formData.set("amount", amount.toString());
 
-  const resp = await fetch(url, {
-    method: "POST",
-    body: formData,
-    headers: {
-      "x-csrftoken": CSRF_TOKEN,
-    },
-  });
-  const data = await resp.json();
+  const data: FallibleRequest<void> = await api
+    .post(url, {
+      body: formData,
+    })
+    .json();
 
   if (data["success"]) {
     alert("Success!");
   } else {
-    alert(`Error: ${data.message}`);
+    alert(`Error: ${data.reason}`);
   }
 }
 

--- a/registration/frontend/src/admin/api.ts
+++ b/registration/frontend/src/admin/api.ts
@@ -1,0 +1,46 @@
+import ky from "ky";
+
+import { CSRF_TOKEN } from "../entrypoints/admin";
+
+const MUTATING_METHODS = new Set(["put", "delete", "post", "patch", "connect"]);
+
+export type FallibleRequest<T> =
+  | {
+      success: false;
+      reason?: string;
+    }
+  | ({ success: true } & T);
+
+export const api = ky.extend({
+  hooks: {
+    beforeRequest: [
+      (request) => {
+        console.debug(`Making ${request.method} request to ${request.url}`);
+
+        if (MUTATING_METHODS.has(request.method.toLowerCase())) {
+          if (!request.headers.has("idempotency-key")) {
+            request.headers.set("idempotency-key", window.crypto.randomUUID());
+          }
+
+          if (CSRF_TOKEN) {
+            request.headers.set("x-csrftoken", CSRF_TOKEN);
+          }
+        }
+      },
+    ],
+    afterResponse: [
+      (request, _options, response) => {
+        console.debug(`Got ${response.status} response from ${request.url}`);
+
+        if (response.redirected && response.url.includes("/admin/login")) {
+          const url = new URL(response.url);
+          url.searchParams.set(
+            "next",
+            window.location.pathname + window.location.search,
+          );
+          window.location.href = url.toString();
+        }
+      },
+    ],
+  },
+});

--- a/registration/frontend/src/admin/attendee-search/index.ts
+++ b/registration/frontend/src/admin/attendee-search/index.ts
@@ -1,4 +1,5 @@
-import { ApisUrls, CSRF_TOKEN } from "../../entrypoints/admin";
+import { ApisUrls } from "../../entrypoints/admin";
+import { api } from "../api";
 import { AttendeeSearch } from "./components/AttendeeSearch";
 
 export { AttendeeSearch };
@@ -27,15 +28,11 @@ export async function getSearchResults(
     return [];
   }
 
-  let url = new URL(urls.onsite_admin_search, window.location.href);
-  url.searchParams.set("search", query);
+  const data = await api
+    .get(urls.onsite_admin_search, {
+      searchParams: { search: query },
+    })
+    .json<{ results: BadgeResult[] }>();
 
-  const resp = await fetch(url, {
-    headers: {
-      "x-csrftoken": CSRF_TOKEN,
-    },
-  });
-  const data = await resp.json();
-
-  return data["results"];
+  return data.results;
 }

--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -1,6 +1,7 @@
 import { Accessor, Setter, createSignal } from "solid-js";
 
-import { ApisUrls, CSRF_TOKEN } from "../../entrypoints/admin";
+import { ApisUrls } from "../../entrypoints/admin";
+import { FallibleRequest, api } from "../api";
 import MqttClient from "../mqtt";
 
 const LOCK_NAME = "onsite-cart-update";
@@ -55,20 +56,15 @@ export class CartManager {
     init?: RequestInit,
   ): Promise<FallibleRequest<T>> {
     const perform = async () => {
-      console.debug("Making request", input);
-      const resp = await fetch(input, {
-        ...init,
-        headers: { "x-csrftoken": CSRF_TOKEN, ...init?.headers },
-      });
-      const data = await resp.json();
-      console.debug("Got response data", input, data);
+      const data = await api(input, init).json<FallibleRequest<T>>();
+      console.debug("Got response data", data);
       return data;
     };
+
     if ("locks" in navigator && navigator.locks) {
-      console.debug("Aquiring cart update lock for request", input);
       return await navigator.locks.request(LOCK_NAME, perform);
     } else {
-      console.warn("locks unavailable, session data might get out of sync!");
+      console.warn("Locks unavailable, session data might get out of sync!");
       return await perform();
     }
   }
@@ -265,13 +261,6 @@ export class CartManager {
     return { success: true } as FallibleRequest<void>;
   }
 }
-
-export type FallibleRequest<T> =
-  | {
-      success: false;
-      reason?: string;
-    }
-  | ({ success: true } & T);
 
 export interface CartResponse {
   charityDonation: string;

--- a/registration/frontend/src/admin/mqtt.tsx
+++ b/registration/frontend/src/admin/mqtt.tsx
@@ -94,7 +94,6 @@ export default class MqttClient {
 
     this.client.on("message", (topic, message) => {
       let data = message.toString();
-      console.debug("MQTT message", topic, data);
 
       let strippedTopic: MqttTopic;
       if (topic.startsWith(webPrefix)) {
@@ -108,6 +107,8 @@ export default class MqttClient {
       try {
         payload = JSON.parse(data);
       } catch (err) {}
+
+      console.debug("MQTT message", topic, payload || data);
 
       switch (strippedTopic) {
         case "authorize/square":

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -335,7 +335,7 @@ def enable_payment(request):
     if cart is None:
         request.session["cart"] = []
         return JsonResponse(
-            {"success": False, "message": "Cart not initialized"}, status=200
+            {"success": False, "reason": "Cart not initialized"}, status=200
         )
 
     badges = []
@@ -418,7 +418,7 @@ def assign_badge_number(request):
     errors = get_messages_list(request)
     if errors:
         return JsonResponse(
-            {"success": False, "errors": errors, "message": "\n".join(errors)},
+            {"success": False, "errors": errors, "reason": "\n".join(errors)},
             status=400,
         )
     return JsonResponse({"success": True})


### PR DESCRIPTION
Currently, there are a number of places in the onsite admin code where network requests are made. In each spot there needs to be handling for adding CSRF tokens and handling error responses, which is getting messy. This updates it to use Ky to add middleware to automatically handle CSRF tokens, idempotency keys, and redirects when a user has been signed out.