### PR TITLE
Improve staff-driven onsite registration

### DIFF
--- a/registration/frontend/src/admin/Navbar.tsx
+++ b/registration/frontend/src/admin/Navbar.tsx
@@ -13,6 +13,7 @@ import {
 
 import { ApisConfig } from "../entrypoints/admin";
 import { FallibleRequest, api } from "./api";
+import { CartManager } from "./cart";
 import { ConfigContext } from "./providers/config-provider";
 import {
   UserSettingKey,
@@ -133,6 +134,7 @@ async function amountRequest(url: string, message: string) {
 const Actions: Component<{
   config: ApisConfig;
   setReadyForNext: Setter<boolean>;
+  cartManager: CartManager;
 }> = (props) => {
   const statusRequestHelper = makeStatusRequestHelper(
     props.config.urls.set_terminal_status,
@@ -161,6 +163,14 @@ const Actions: Component<{
         action={() => {
           statusRequestHelper("ready");
           props.setReadyForNext(true);
+        }}
+      />
+
+      <ActionButton
+        name="Cancel Registration"
+        icon="fas fa-user-slash"
+        action={() => {
+          props.cartManager.cancelRegistration();
         }}
       />
 
@@ -329,6 +339,7 @@ const ToggleSetting: Component<{
 
 export const Navbar: Component<{
   setReadyForNext: Setter<boolean>;
+  cartManager: CartManager;
 }> = (props) => {
   const config = useContext(ConfigContext)!;
   const userSettings = useContext(UserSettingsContext)!;
@@ -404,7 +415,11 @@ export const Navbar: Component<{
               <i class="fas fa-cog"></i>
             </a>
 
-            <Actions config={config} setReadyForNext={props.setReadyForNext} />
+            <Actions
+              config={config}
+              setReadyForNext={props.setReadyForNext}
+              cartManager={props.cartManager}
+            />
           </div>
 
           <div class="navbar-item has-dropdown is-hoverable">

--- a/registration/frontend/src/admin/Onsite.tsx
+++ b/registration/frontend/src/admin/Onsite.tsx
@@ -41,6 +41,7 @@ export const Onsite: Component<{
         />
 
         <ScanPanel
+          cartManager={props.cartManager}
           gotScannedName={(name, birthday) => {
             const query =
               birthday && userSettings.userSettings().search_birthday

--- a/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
+++ b/registration/frontend/src/admin/attendee-search/components/AttendeeSearch.tsx
@@ -15,6 +15,7 @@ import {
 import { BadgeResult, getSearchResults } from "..";
 import { SentryErrorBoundary } from "../../../entrypoints/admin";
 import { CartManager } from "../../cart";
+import { DisplayRegistrationButton } from "../../components/DisplayRegistration";
 import { ConfigContext } from "../../providers/config-provider";
 import { BadgeTableLoader } from "./BadgeTableLoader";
 import { BadgeTableRow } from "./BadgeTableRow";
@@ -187,17 +188,29 @@ export const AttendeeSearch: Component<{
               <div class="column is-align-self-center">Attendee Search</div>
 
               <div class="column is-narrow">
-                <a
-                  href={config.urls.onsite}
-                  target="register"
-                  title="Control+N"
-                  class="button is-link is-small"
-                >
-                  <span class="icon">
-                    <i class="fas fa-plus"></i>
-                  </span>
-                  <span>New</span>
-                </a>
+                <div class="buttons">
+                  <a
+                    href={config.urls.onsite}
+                    target="register"
+                    title="Control+N"
+                    class="button is-link is-small"
+                  >
+                    <span class="icon">
+                      <i class="fas fa-plus"></i>
+                    </span>
+                    <span>New</span>
+                  </a>
+
+                  <DisplayRegistrationButton
+                    cartManager={props.cartManager}
+                    class="button is-secondary is-small"
+                  >
+                    <span class="icon">
+                      <i class="fas fa-clipboard-user"></i>
+                    </span>
+                    <span>Prompt</span>
+                  </DisplayRegistrationButton>
+                </div>
               </div>
             </div>
           </div>

--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -2,6 +2,7 @@ import { Accessor, Setter, createSignal } from "solid-js";
 
 import { ApisUrls } from "../../entrypoints/admin";
 import { FallibleRequest, api } from "../api";
+import { AttendeeDetails } from "../components/DisplayRegistration";
 import MqttClient from "../mqtt";
 
 const LOCK_NAME = "onsite-cart-update";
@@ -29,11 +30,27 @@ export class CartManager {
 
     this.mqtt.emitter.on("refresh", this.refreshCart.bind(this));
     this.mqtt.emitter.on("transfer", this.addPendingTransfer.bind(this));
+    this.mqtt.emitter.on(
+      "registration/completed",
+      this.completedRegistration.bind(this),
+    );
   }
 
   close() {
     this.mqtt.emitter.off("refresh", this.refreshCart.bind(this));
     this.mqtt.emitter.off("transfer", this.addPendingTransfer.bind(this));
+    this.mqtt.emitter.off(
+      "registration/completed",
+      this.completedRegistration.bind(this),
+    );
+  }
+
+  private completedRegistration(payload: object | null) {
+    const badgeId =
+      payload && "badgeId" in payload && (payload["badgeId"] as number);
+    if (badgeId) {
+      this.addCartId(badgeId);
+    }
   }
 
   private addPendingTransfer(payload: object | null) {
@@ -259,6 +276,38 @@ export class CartManager {
     await this.clearCart();
 
     return { success: true } as FallibleRequest<void>;
+  }
+
+  public getOnsiteUrl(details: AttendeeDetails): URL {
+    const regUrl = new URL(this.urls.onsite, window.location.href);
+    Object.entries(details).forEach(([name, value]) => {
+      regUrl.searchParams.set(name, value);
+    });
+    return regUrl;
+  }
+
+  public async displayRegistration(
+    details: AttendeeDetails,
+  ): Promise<FallibleRequest<void>> {
+    let url = new URL(this.urls.onsite_regtoken, window.location.href);
+    const resp = await this.makeRequest<{ token: String }>(url);
+    if (!resp.success) {
+      return resp;
+    }
+
+    const regUrl = this.getOnsiteUrl(details);
+
+    this.mqtt.publishMessage(
+      "payment/registration/display",
+      JSON.stringify({
+        url: regUrl.toString(),
+        token: resp.token,
+      }),
+    );
+  }
+
+  public cancelRegistration() {
+    this.mqtt.publishMessage("payment/registration/cancel", JSON.stringify({}));
   }
 }
 

--- a/registration/frontend/src/admin/cart/cart-manager.ts
+++ b/registration/frontend/src/admin/cart/cart-manager.ts
@@ -290,7 +290,7 @@ export class CartManager {
     details: AttendeeDetails,
   ): Promise<FallibleRequest<void>> {
     let url = new URL(this.urls.onsite_regtoken, window.location.href);
-    const resp = await this.makeRequest<{ token: String }>(url);
+    const resp = await api.post(url).json<FallibleRequest<{ token: String }>>();
     if (!resp.success) {
       return resp;
     }
@@ -308,6 +308,16 @@ export class CartManager {
 
   public cancelRegistration() {
     this.mqtt.publishMessage("payment/registration/cancel", JSON.stringify({}));
+  }
+
+  public async fetchAttendeeDetails(
+    badgeId: number,
+  ): Promise<FallibleRequest<{ attendee: AttendeeDetails }>> {
+    return await api
+      .get(this.urls.onsite_attendee_details, {
+        searchParams: { id: badgeId },
+      })
+      .json();
   }
 }
 

--- a/registration/frontend/src/admin/cart/components/CartBadge.tsx
+++ b/registration/frontend/src/admin/cart/components/CartBadge.tsx
@@ -1,7 +1,14 @@
 import { ContextMenu } from "@kobalte/core/context-menu";
-import { Component, Show, createResource, createSignal } from "solid-js";
+import {
+  Component,
+  Show,
+  createResource,
+  createSignal,
+  useContext,
+} from "solid-js";
 
 import { AttendeeDetails } from "../../components/DisplayRegistration";
+import { ConfigContext } from "../../providers/config-provider";
 import { Badge, CartManager } from "../cart-manager";
 import { cleanMoneyAmount } from "./CartEntries";
 
@@ -57,6 +64,8 @@ const createAttendee = async (
 export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
   props,
 ) => {
+  const config = useContext(ConfigContext)!;
+
   const [clearPrintBadgeId, setClearPrintBadgeId] = createSignal<number>();
   createResource(clearPrintBadgeId, async (id) => {
     const resp = await props.manager.clearBadgePrinted(id);
@@ -145,7 +154,6 @@ export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
                       >
                         New Basic
                       </ContextMenu.Item>
-
                       <ContextMenu.Item
                         as="a"
                         class="dropdown-item"
@@ -154,21 +162,22 @@ export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
                         New Clone
                       </ContextMenu.Item>
 
-                      <ContextMenu.Item
-                        as="a"
-                        class="dropdown-item"
-                        onClick={() => create(true, true)}
-                      >
-                        Prompt Basic
-                      </ContextMenu.Item>
-
-                      <ContextMenu.Item
-                        as="a"
-                        class="dropdown-item"
-                        onClick={() => create(false, true)}
-                      >
-                        Prompt Clone
-                      </ContextMenu.Item>
+                      <Show when={config.terminals.selected?.features.prompt}>
+                        <ContextMenu.Item
+                          as="a"
+                          class="dropdown-item"
+                          onClick={() => create(true, true)}
+                        >
+                          Prompt Basic
+                        </ContextMenu.Item>
+                        <ContextMenu.Item
+                          as="a"
+                          class="dropdown-item"
+                          onClick={() => create(false, true)}
+                        >
+                          Prompt Clone
+                        </ContextMenu.Item>
+                      </Show>
                     </div>
                   </div>
                 </ContextMenu.Content>

--- a/registration/frontend/src/admin/cart/components/CartBadge.tsx
+++ b/registration/frontend/src/admin/cart/components/CartBadge.tsx
@@ -1,13 +1,64 @@
+import { ContextMenu } from "@kobalte/core/context-menu";
 import { Component, Show, createResource, createSignal } from "solid-js";
 
+import { AttendeeDetails } from "../../components/DisplayRegistration";
 import { Badge, CartManager } from "../cart-manager";
 import { cleanMoneyAmount } from "./CartEntries";
+
+type AttendeeDetailField = keyof AttendeeDetails;
+
+const BASIC_FIELDS: AttendeeDetailField[] = [
+  "address1",
+  "address2",
+  "city",
+  "state",
+  "country",
+  "postalCode",
+];
+const CLONE_FIELDS: AttendeeDetailField[] = (
+  ["lastName", "email", "phone"] as AttendeeDetailField[]
+).concat(BASIC_FIELDS);
+
+const filterDetails = (
+  details: AttendeeDetails,
+  fields: AttendeeDetailField[],
+): AttendeeDetails => {
+  for (const detailKey in details) {
+    const key = detailKey as AttendeeDetailField;
+    if (!fields.includes(key)) delete details[key];
+  }
+  return details;
+};
+
+const createAttendee = async (
+  cartManager: CartManager,
+  badgeId: number,
+  onlyBasic: boolean,
+  prompt: boolean,
+) => {
+  const details = await cartManager.fetchAttendeeDetails(badgeId);
+  if (!details.success) {
+    return alert("Unable to get attendee details");
+  }
+
+  const fields = filterDetails(
+    details.attendee,
+    onlyBasic ? BASIC_FIELDS : CLONE_FIELDS,
+  );
+
+  if (prompt) {
+    await cartManager.displayRegistration(fields);
+  } else {
+    const url = cartManager.getOnsiteUrl(fields);
+    window.open(url, "register");
+  }
+};
 
 export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
   props,
 ) => {
   const [clearPrintBadgeId, setClearPrintBadgeId] = createSignal<number>();
-  const [clearPrint] = createResource(clearPrintBadgeId, async (id) => {
+  createResource(clearPrintBadgeId, async (id) => {
     const resp = await props.manager.clearBadgePrinted(id);
     if (resp.success) {
       await props.manager.refreshCart();
@@ -20,6 +71,17 @@ export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
   const [remove] = createResource(removeBadgeId, async (id) => {
     await props.manager.removeBadge(id);
   });
+
+  const promptClearPrint = () => {
+    if (
+      confirm("Are you sure you need to clear the print flag for this badge?")
+    ) {
+      setClearPrintBadgeId(props.badge.id);
+    }
+  };
+
+  const create = (onlyBasic: boolean, prompt: boolean) =>
+    createAttendee(props.manager, props.badge.id, onlyBasic, prompt);
 
   return (
     <div class="block control">
@@ -42,31 +104,76 @@ export const CartBadge: Component<{ manager: CartManager; badge: Badge }> = (
             </Show>
 
             <Show when={props.badge.printed}>
-              <button
-                class="tag is-link"
-                classList={{ "is-loading": clearPrint.loading }}
-                title="Already printed"
-                onClick={() => {
-                  if (
-                    confirm(
-                      "Are you sure you need to clear the print flag for this badge?",
-                    )
-                  ) {
-                    setClearPrintBadgeId(props.badge.id);
-                  }
-                }}
-              >
+              <span class="tag is-link" title="Already printed">
                 <span class="icon">
                   <i class="fas fa-print" />
                 </span>
-              </button>
+              </span>
             </Show>
           </div>
 
           <div class="mr-2 is-flex-grow-1">
-            <a href={props.manager.urlForBadge(props.badge.id)} target="edit">
-              {`${props.badge.firstName} ${props.badge.lastName}`}
-            </a>
+            <ContextMenu preventScroll={false}>
+              <ContextMenu.Trigger
+                as="a"
+                href={props.manager.urlForBadge(props.badge.id)}
+                target="edit"
+              >
+                {`${props.badge.firstName} ${props.badge.lastName}`}
+              </ContextMenu.Trigger>
+
+              <ContextMenu.Portal>
+                <ContextMenu.Content class="dropdown is-active">
+                  <div class="dropdown-menu">
+                    <div class="dropdown-content">
+                      <ContextMenu.Item
+                        as="a"
+                        class="dropdown-item"
+                        classList={{ "is-disabled": !props.badge.printed }}
+                        disabled={!props.badge.printed}
+                        onClick={promptClearPrint}
+                      >
+                        Clear Print
+                      </ContextMenu.Item>
+
+                      <ContextMenu.Separator class="dropdown-divider" />
+
+                      <ContextMenu.Item
+                        as="a"
+                        class="dropdown-item"
+                        onClick={() => create(true, false)}
+                      >
+                        New Basic
+                      </ContextMenu.Item>
+
+                      <ContextMenu.Item
+                        as="a"
+                        class="dropdown-item"
+                        onClick={() => create(false, false)}
+                      >
+                        New Clone
+                      </ContextMenu.Item>
+
+                      <ContextMenu.Item
+                        as="a"
+                        class="dropdown-item"
+                        onClick={() => create(true, true)}
+                      >
+                        Prompt Basic
+                      </ContextMenu.Item>
+
+                      <ContextMenu.Item
+                        as="a"
+                        class="dropdown-item"
+                        onClick={() => create(false, true)}
+                      >
+                        Prompt Clone
+                      </ContextMenu.Item>
+                    </div>
+                  </div>
+                </ContextMenu.Content>
+              </ContextMenu.Portal>
+            </ContextMenu>
           </div>
 
           <div>

--- a/registration/frontend/src/admin/components/DisplayRegistration.tsx
+++ b/registration/frontend/src/admin/components/DisplayRegistration.tsx
@@ -1,0 +1,57 @@
+import {
+  Accessor,
+  Component,
+  type JSX,
+  createSignal,
+  splitProps,
+} from "solid-js";
+
+import { CartManager } from "../cart/cart-manager";
+
+export type AttendeeDetails = {
+  firstName?: string;
+  lastName?: string;
+  preferredName?: string;
+  email?: string;
+  phone?: string;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  postalCode?: string;
+  dob?: string;
+};
+
+export const DisplayRegistrationButton: Component<
+  {
+    children: JSX.Element;
+    cartManager: CartManager;
+    details?: Accessor<AttendeeDetails>;
+  } & JSX.IntrinsicElements["button"]
+> = (props) => {
+  const [customProps, buttonProps] = splitProps(props, [
+    "children",
+    "cartManager",
+    "details",
+  ]);
+
+  const [isLoading, setIsLoading] = createSignal(false);
+
+  const display = async () => {
+    setIsLoading(true);
+    customProps.cartManager.displayRegistration(customProps.details?.() || {});
+    setIsLoading(false);
+  };
+
+  return (
+    <button
+      type="button"
+      {...buttonProps}
+      classList={{ "is-loading": isLoading() }}
+      onClick={() => display()}
+    >
+      {customProps.children}
+    </button>
+  );
+};

--- a/registration/frontend/src/admin/components/DisplayRegistration.tsx
+++ b/registration/frontend/src/admin/components/DisplayRegistration.tsx
@@ -2,11 +2,14 @@ import {
   Accessor,
   Component,
   type JSX,
+  Show,
   createSignal,
   splitProps,
+  useContext,
 } from "solid-js";
 
 import { CartManager } from "../cart/cart-manager";
+import { ConfigContext } from "../providers/config-provider";
 
 export type AttendeeDetails = {
   firstName?: string;
@@ -30,6 +33,8 @@ export const DisplayRegistrationButton: Component<
     details?: Accessor<AttendeeDetails>;
   } & JSX.IntrinsicElements["button"]
 > = (props) => {
+  const config = useContext(ConfigContext)!;
+
   const [customProps, buttonProps] = splitProps(props, [
     "children",
     "cartManager",
@@ -45,13 +50,15 @@ export const DisplayRegistrationButton: Component<
   };
 
   return (
-    <button
-      type="button"
-      {...buttonProps}
-      classList={{ "is-loading": isLoading() }}
-      onClick={() => display()}
-    >
-      {customProps.children}
-    </button>
+    <Show when={config.terminals.selected?.features.prompt}>
+      <button
+        type="button"
+        {...buttonProps}
+        classList={{ "is-loading": isLoading() }}
+        onClick={() => display()}
+      >
+        {customProps.children}
+      </button>
+    </Show>
   );
 };

--- a/registration/frontend/src/admin/index.scss
+++ b/registration/frontend/src/admin/index.scss
@@ -42,6 +42,12 @@
   display: inline-flex;
 }
 
+.dropdown-menu .dropdown-item.is-disabled {
+  color: var(--bulma-text-soft);
+  cursor: default;
+  pointer-events: none;
+}
+
 @include mixins.tablet {
   .badge-actions {
     flex-wrap: nowrap;

--- a/registration/frontend/src/admin/mqtt.tsx
+++ b/registration/frontend/src/admin/mqtt.tsx
@@ -15,6 +15,7 @@ export type MqttTopic =
   | "notify/scan/url"
   | "presence"
   | "refresh"
+  | "registration/completed"
   | "transfer";
 
 export type MqttEmitter = Emitter<Record<MqttTopic, object | null>>;
@@ -24,6 +25,8 @@ const KNOWN_MESSAGES: Record<string, [string, string]> = {
   payment_cancelled: ["Payment cancelled", "is-warning"],
   payment_failed: ["Payment failed", "is-danger"],
   payment_completed: ["Payment completed", "is-success"],
+  registration_opened: ["Registration page opened", "is-info"],
+  registration_completed: ["Registration completed", "is-success"],
 };
 
 const getDeviceId = (): string => {
@@ -55,7 +58,7 @@ export default class MqttClient {
 
     if (!this.config.auth) return;
 
-    const wildcardTopic = this.getPrefixedTopic("#");
+    const wildcardTopic = this.getPrefixedTopic("web/#");
 
     this.client = mqtt.connect(config.broker, {
       username: config.auth.user,
@@ -69,9 +72,11 @@ export default class MqttClient {
       },
     });
 
-    this.client.on("connect", () => {
+    this.client.on("connect", (packet) => {
       this.setErrorMessage(undefined);
-      console.debug(`Subscribing to ${wildcardTopic}`);
+      console.debug(
+        `Connected to MQTT, sessionPresent - ${packet.sessionPresent}, subscribing to ${wildcardTopic}`,
+      );
       this.client?.subscribe(wildcardTopic, (err) => {
         if (err) {
           console.error(`MQTT subscription failed: ${err}`);
@@ -106,7 +111,7 @@ export default class MqttClient {
       let payload = null;
       try {
         payload = JSON.parse(data);
-      } catch (err) {}
+      } catch (_err) {}
 
       console.debug("MQTT message", topic, payload || data);
 
@@ -116,6 +121,7 @@ export default class MqttClient {
             document.cookie = `square_oauth_state=${payload["state"]}; path=/`;
             window.open(payload["url"], "square_oauth");
           }
+          break;
         case "notify/alert":
           if (payload?.["text"]) {
             alert(payload["text"]);

--- a/registration/frontend/src/admin/scan/components/IdEntry.tsx
+++ b/registration/frontend/src/admin/scan/components/IdEntry.tsx
@@ -1,15 +1,21 @@
 import { createShortcut } from "@solid-primitives/keyboard";
 import { differenceInYears } from "date-fns/differenceInYears";
-import { Component, Show, createMemo, useContext } from "solid-js";
+import { Component, Show } from "solid-js";
 
 import { IdData } from "..";
-import { ConfigContext } from "../../providers/config-provider";
+import { CartManager } from "../../cart";
+import {
+  AttendeeDetails,
+  DisplayRegistrationButton,
+} from "../../components/DisplayRegistration";
 import { CloseButton } from "./CloseButton";
 import { NameBirthday } from "./ScanPii";
 
-export const IdEntry: Component<{ data: IdData; remove(): void }> = (props) => {
-  const config = useContext(ConfigContext)!;
-
+export const IdEntry: Component<{
+  data: IdData;
+  remove(): void;
+  cartManager: CartManager;
+}> = (props) => {
   const expirationDate = () => new Date(props.data.expiry);
   const expired = () => new Date() > expirationDate();
 
@@ -22,22 +28,27 @@ export const IdEntry: Component<{ data: IdData; remove(): void }> = (props) => {
     };
   };
 
-  const regUrl = createMemo(() => {
-    let url = new URL(config.urls.onsite, window.location.href);
-    url.searchParams.set("firstName", props.data.first);
-    url.searchParams.set("lastName", props.data.last);
-    url.searchParams.set("dob", props.data.dob);
+  const attendeeDetails = () => {
+    const details: AttendeeDetails = {
+      firstName: props.data.first,
+      lastName: props.data.last,
+      dob: props.data.dob,
+    };
+
     if (props.data.address) {
       const address = props.data.address;
-      url.searchParams.set("address1", address.address);
-      if (address.address2) url.searchParams.set("address2", address.address2);
-      url.searchParams.set("city", address.city);
-      url.searchParams.set("state", address.state);
-      url.searchParams.set("postalCode", address.ZIP.substring(0, 5));
+      details.address1 = address.address;
+      if (address.address2) details.address2 = address.address2;
+      details.city = address.city;
+      details.state = address.state;
+      details.postalCode = address.ZIP.substring(0, 5);
     }
 
-    return url.toString();
-  });
+    return details;
+  };
+
+  const regUrl = () =>
+    props.cartManager.getOnsiteUrl(attendeeDetails()).toString();
 
   createShortcut(
     ["Control", "M"],
@@ -90,7 +101,7 @@ export const IdEntry: Component<{ data: IdData; remove(): void }> = (props) => {
           birthday={props.data.dob}
         />
 
-        <div>
+        <div class="buttons">
           <a
             href={regUrl()}
             class="button is-link"
@@ -102,6 +113,17 @@ export const IdEntry: Component<{ data: IdData; remove(): void }> = (props) => {
             </span>
             <span>Create Attendee</span>
           </a>
+
+          <DisplayRegistrationButton
+            details={attendeeDetails}
+            cartManager={props.cartManager}
+            class="button is-secondary"
+          >
+            <span class="icon">
+              <i class="fas fa-clipboard-user"></i>
+            </span>
+            <span>Prompt Registration</span>
+          </DisplayRegistrationButton>
         </div>
       </div>
     </article>

--- a/registration/frontend/src/admin/scan/components/ScanPanel.tsx
+++ b/registration/frontend/src/admin/scan/components/ScanPanel.tsx
@@ -3,6 +3,7 @@ import { Accessor, Component, Show, createEffect, createMemo } from "solid-js";
 import { createStore } from "solid-js/store";
 
 import { IdData, ShcData } from "..";
+import { CartManager } from "../../cart";
 import { MqttEmitter } from "../../mqtt";
 import { IdEntry } from "./IdEntry";
 import { ShcEntry } from "./ShcEntry";
@@ -18,6 +19,7 @@ export const ScanPanel: Component<{
   gotScannedName(name: string, birthday?: string): void;
   readyForNext: Accessor<boolean>;
   emitter: MqttEmitter;
+  cartManager: CartManager;
 }> = (props) => {
   const [store, setStore] = createStore<ScanStore>({
     id: undefined,
@@ -125,6 +127,7 @@ export const ScanPanel: Component<{
         <Show when={store.id}>
           <div class="panel-block">
             <IdEntry
+              cartManager={props.cartManager}
               data={store.id!}
               remove={() => setStore("id", undefined)}
             />

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -84,6 +84,7 @@ export interface ApisUrls {
   onsite_print_badges: string;
   onsite_print_clear: string;
   onsite_print_receipts: string;
+  onsite_regtoken: string;
   onsite_remove_from_cart: string;
   onsite: string;
   open_drawer: string;
@@ -184,7 +185,7 @@ function start() {
     return (
       <ConfigContext.Provider value={APIS_CONFIG}>
         <UserSettingsContext.Provider value={userSettings}>
-          <Navbar setReadyForNext={setReadyForNext} />
+          <Navbar setReadyForNext={setReadyForNext} cartManager={cartManager} />
 
           <For each={APIS_CONFIG.errors}>
             {(error) => (

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -80,6 +80,7 @@ export interface ApisUrls {
   onsite_admin_search: string;
   onsite_admin_transfer_cart: string;
   onsite_admin: string;
+  onsite_attendee_details: string;
   onsite_create_discount: string;
   onsite_print_badges: string;
   onsite_print_clear: string;

--- a/registration/frontend/src/entrypoints/admin.tsx
+++ b/registration/frontend/src/entrypoints/admin.tsx
@@ -114,6 +114,7 @@ export interface ApisSelectedTerminal {
 export interface ApisTerminalFeatures {
   card: boolean;
   cashdrawer: boolean;
+  prompt: boolean;
   square_terminal: boolean;
 }
 

--- a/registration/templates/registration/onsite.html
+++ b/registration/templates/registration/onsite.html
@@ -184,6 +184,8 @@
     </div>
   </script>
 
+  <script src="{% static 'js/date-entry.js' %}"></script>
+
   <script type="text/javascript">
       let levelTemplateData = [];
       let minorLevelTemplateData = [];
@@ -228,6 +230,7 @@
       }
 
       $("body").ready(function () {
+          updatePriceLevels();
           $("#bday, #bmonth, #byear").on("input", function() {
             updatePriceLevels();
           });
@@ -309,7 +312,6 @@
               }
 
               let level_data = levelTemplateData;
-              debugger;
 
               if (age < 0) {
                   alert("You must be born before today to exist.\n(Please check your date of birth and try again)");
@@ -521,8 +523,6 @@
           $("#register").one('click', register_click);
       });
   </script>
-
-  <script src="{% static 'js/date-entry.js' %}"></script>
 
 
 {% endblock %}

--- a/registration/templates/templatetags/basic_attendee_form.html
+++ b/registration/templates/templatetags/basic_attendee_form.html
@@ -153,7 +153,7 @@
 
         <input type="hidden" name="birthDate" id="birthDate" value="{{attendee.birthdate|date:"Y-m-d"}}{{ attendee.dob }}">
 
-        <p><button class="btn btn-link btn-sm" data-toggle="modal" data-target="#ageModal">Why do we need this?</button></p>
+        <p><button type="button" class="btn btn-link btn-sm" data-toggle="modal" data-target="#ageModal">Why do we need this?</button></p>
     </div>
     <div class="col-sm-offset-3 help-block with-errors" style="padding-left:15px;"></div>
 </div>

--- a/registration/urls.py
+++ b/registration/urls.py
@@ -251,6 +251,11 @@ urlpatterns = [
         registration.views.onsite_admin.create_discount,
         name="onsite_create_discount",
     ),
+    path(
+        "onsite/admin/regtoken",
+        registration.views.onsite_admin.regtoken,
+        name="onsite_regtoken"
+    ),
     re_path(r"^cart/?$", registration.views.cart.get_cart, name="cart"),
     re_path(r"^cart/add/?$", registration.views.cart.add_to_cart, name="add_to_cart"),
     re_path(

--- a/registration/urls.py
+++ b/registration/urls.py
@@ -256,6 +256,11 @@ urlpatterns = [
         registration.views.onsite_admin.regtoken,
         name="onsite_regtoken"
     ),
+    path(
+        "onsite/admin/attendee",
+        registration.views.onsite_admin.attendee_details,
+        name="onsite_attendee_details"
+    ),
     re_path(r"^cart/?$", registration.views.cart.get_cart, name="cart"),
     re_path(r"^cart/add/?$", registration.views.cart.add_to_cart, name="add_to_cart"),
     re_path(

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -118,9 +118,10 @@ def onsite_admin(request):
         selected_terminal = {
             "id": terminal.id,
             "features": {
-                "square_terminal": terminal.square_terminal_id is not None,
                 "card": terminal.payment_type is not None,
                 "cashdrawer": terminal.cashdrawer,
+                "prompt": terminal.payment_type == Firebase.MQTT_REGISTER_APP,
+                "square_terminal": terminal.square_terminal_id is not None,
             },
         }
 

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -159,6 +159,7 @@ def onsite_admin(request):
                 "onsite_admin_search": reverse("registration:onsite_admin_search"),
                 "onsite_admin_transfer_cart": reverse("registration:onsite_admin_transfer_cart"),
                 "onsite_admin": reverse("registration:onsite_admin"),
+                "onsite_attendee_details": reverse("registration:onsite_attendee_details"),
                 "onsite_create_discount": reverse("registration:onsite_create_discount"),
                 "onsite_print_badges": reverse("registration:onsite_print_badges"),
                 "onsite_print_clear": reverse("registration:onsite_print_clear"),
@@ -1195,6 +1196,42 @@ def regtoken(request):
     })
 
     return JsonResponse({"success": True, "token": data})
+
+
+@staff_member_required
+def attendee_details(request):
+    id = request.GET.get("id", None)
+    if id is None or id == "":
+        return JsonResponse(
+            {"success": False, "reason": "Need ID parameter"}, status=400
+        )
+
+    try:
+        id = int(id)
+    except ValueError:
+        return JsonResponse(
+            {"success": False, "reason": "ID parameter must be integer"}, status=400
+        )
+
+    attendee = Badge.objects.get(id=id).attendee
+
+    return JsonResponse({
+        "success": True,
+        "attendee": {
+            "firstName": attendee.firstName,
+            "lastName": attendee.lastName,
+            "preferredName": attendee.preferredName,
+            "email": attendee.email,
+            "phone": attendee.phone,
+            "address1": attendee.address1,
+            "address2": attendee.address2,
+            "city": attendee.city,
+            "state": attendee.state,
+            "country": attendee.country,
+            "postalCode": attendee.postalCode,
+            "dob": attendee.birthdate,
+        }
+    })
 
 
 @csrf_exempt

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -163,6 +163,7 @@ def onsite_admin(request):
                 "onsite_print_badges": reverse("registration:onsite_print_badges"),
                 "onsite_print_clear": reverse("registration:onsite_print_clear"),
                 "onsite_print_receipts": reverse("registration:onsite_print_receipts"),
+                "onsite_regtoken": reverse("registration:onsite_regtoken"),
                 "onsite_remove_from_cart": reverse("registration:onsite_remove_from_cart"),
                 "onsite": reverse("registration:onsite"),
                 "open_drawer": reverse("registration:open_drawer"),
@@ -1178,6 +1179,22 @@ def onsite_print_clear(request):
     badge.save()
 
     return JsonResponse({"success": True})
+
+
+@staff_member_required
+def regtoken(request):
+    terminal = get_active_terminal(request)
+    if not terminal:
+        return JsonResponse(
+            {"success": False, "reason": "No terminal attached to session"}, status=400
+        )
+
+    signer = TimestampSigner()
+    data = signer.sign_object({
+        "terminal": terminal.name,
+    })
+
+    return JsonResponse({"success": True, "token": data})
 
 
 @csrf_exempt

--- a/registration/views/ordering.py
+++ b/registration/views/ordering.py
@@ -3,9 +3,11 @@ import logging
 import time
 from json import JSONDecodeError
 
+from django.core.signing import TimestampSigner
 from django.http import JsonResponse
 from idempotency_key.decorators import idempotency_key
 
+from registration import mqtt
 import registration.emails
 from registration.models import *
 from registration.payments import charge_payment
@@ -368,6 +370,8 @@ def checkout(request):
                 ),
             )
 
+        notify_terminal(request, order)
+
         return common.success()
     else:
         return common.abort(400, message)
@@ -396,3 +400,22 @@ def cancel_order(request):
     # Clear session values
     common.clear_session(request)
     return common.success()
+
+
+def notify_terminal(request, order):
+    try:
+        associated_terminal = request.COOKIES.get("terminal-token")
+        if associated_terminal:
+            signer = TimestampSigner()
+            data_obj = signer.unsign_object(associated_terminal, max_age=60 * 30)
+            # We only need one badge ID as onsite will automatically add all
+            # badges attached to the order.
+            order_item = OrderItem.objects.filter(order_id=order.id).first()
+            if order_item:
+                mqtt.send_mqtt_message(
+                    mqtt.get_topic("web/registration/completed", name=data_obj["terminal"]),
+                    {"badgeId": order_item.badge_id},
+                )
+    except Exception as ex:
+        logger.warning(f"Could not use terminal-token: {ex}")
+        pass


### PR DESCRIPTION
This PR adds two new features:

1. The ability to clone attendee details when creating onsite registrations. There are two options, "Basic" and "Clone," which control how much information is prefilled. Basic only includes address information. Clone includes email, phone, and last name, intended mostly for minor registration where all of that information is the same.
2. A concept of prompting registration which allows attendees to use the iPad to fill out the remaining fields. This is also supported when an ID was scanned. This brings up our onsite reg page on the iPad with the selected information. It's also hooked into the current terminal and when completed will automatically be added to the cart.


<img width="399" height="258" alt="Screenshot 2026-01-30 at 2 53 29 PM" src="https://github.com/user-attachments/assets/3c82195a-cd86-4b2a-92b3-6588eb7c466d" />

