### PR TITLE
Allow specifying allauth trusted IP header

### DIFF
--- a/fm_eventmanager/settings.py.docker
+++ b/fm_eventmanager/settings.py.docker
@@ -272,6 +272,8 @@ MFA_SUPPORTED_TYPES = ["totp", "webauthn", "recovery_codes"]
 MFA_PASSKEY_LOGIN_ENABLED = True
 MFA_ADAPTER = "allauth.mfa.adapter.DefaultMFAAdapter"
 
+ALLAUTH_TRUSTED_CLIENT_IP_HEADER = os.getenv("TRUSTED_CLIENT_IP_HEADER")
+
 LOGIN_REDIRECT_URL = "admin:index"
 
 IDEMPOTENCY_KEY = {


### PR DESCRIPTION
A patch release of allauth completely broke the ability to sign in, cool!