### PR TITLE
Add support for Web HID barcode scanners

### DIFF
--- a/registration/frontend/package-lock.json
+++ b/registration/frontend/package-lock.json
@@ -11,9 +11,12 @@
         "@sentry/solid": "^10.44.0",
         "@solid-primitives/context": "^0.3.2",
         "@solid-primitives/date": "^2.1.6",
+        "@solid-primitives/event-bus": "^1.1.3",
         "@solid-primitives/history": "^0.2.3",
         "@solid-primitives/memo": "^1.4.5",
         "@solid-primitives/presence": "^0.1.3",
+        "@syfaro/aamva-web": "^0.1.0",
+        "@syfaro/scanners-and-such-web": "^0.1.0",
         "@tanstack/solid-devtools": "^0.8.0",
         "@tanstack/solid-hotkeys": "^0.4.1",
         "@tanstack/solid-hotkeys-devtools": "^0.4.2",
@@ -28,6 +31,7 @@
         "lodash": "^4.17.23",
         "mitt": "^3.0.1",
         "mqtt": "^5.14.1",
+        "mrtd": "^1.0.0",
         "solid-fa": "^0.2.0",
         "solid-js": "^1.9.10"
       },
@@ -39,6 +43,7 @@
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/big.js": "^6.2.2",
         "@types/lodash": "^4.17.24",
+        "@types/w3c-web-hid": "^1.0.6",
         "baseline-browser-mapping": "^2.10.8",
         "eslint": "^9.39.1",
         "eslint-plugin-solid": "^0.14.5",
@@ -50,6 +55,7 @@
         "typescript-eslint": "^8.57.1",
         "vite": "^7.3.1",
         "vite-plugin-solid": "^2.11.11",
+        "vite-plugin-wasm": "^3.5.0",
         "vite-tsconfig-paths": "^6.1.1"
       }
     },
@@ -2071,6 +2077,18 @@
         "solid-js": "^1.6.12"
       }
     },
+    "node_modules/@solid-primitives/event-bus": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/event-bus/-/event-bus-1.1.3.tgz",
+      "integrity": "sha512-cVW/YIG3iXRBhA/KNPeD89bR2cZkDok1Tl8ZWtYpbu0AfZVFeI7nyZjWbYLaYPXzlZouau2fU/lEuKcInQ6s8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solid-primitives/utils": "^6.4.0"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.6.12"
+      }
+    },
     "node_modules/@solid-primitives/event-listener": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.5.tgz",
@@ -2302,6 +2320,16 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@syfaro/aamva-web": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@syfaro/aamva-web/-/aamva-web-0.1.1.tgz",
+      "integrity": "sha512-FvsROmeacJUWOJ5Z9HX+/VoVS93qnrqpC6jVyGmzwT4A/eVaXmeS4R0sFZbrhtAUXlTknvyE0hRdw7KSxuJ0PA=="
+    },
+    "node_modules/@syfaro/scanners-and-such-web": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@syfaro/scanners-and-such-web/-/scanners-and-such-web-0.1.2.tgz",
+      "integrity": "sha512-oY2kiLPffrA5dR+bZ5gnwS14cPViNIjdVlrBKI/uRm0jdlCToqOIDxJf9Jy4asQD5X3P2ibaHC9KIYUNnLyUCA=="
     },
     "node_modules/@tanstack/devtools": {
       "version": "0.11.0",
@@ -3046,6 +3074,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/w3c-web-hid": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-hid/-/w3c-web-hid-1.0.6.tgz",
+      "integrity": "sha512-IWyssXmRDo6K7s31dxf+U+x/XUWuVsl9qUIYbJmpUHPcTv/COfBCKw/F0smI45+gPV34brjyP30BFcIsHgYWLA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -5055,6 +5090,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/mrtd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrtd/-/mrtd-1.0.0.tgz",
+      "integrity": "sha512-g5t1/Voeq4Qi2FDfnSuQnyDMFHXyYl3xFbt3fyH8OvnSqZDQMGSZ+uyEgyop1X21EipTdsTHN46Mh7GOjfY1jw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6520,6 +6561,16 @@
         "@testing-library/jest-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.6.0.tgz",
+      "integrity": "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/vite-tsconfig-paths": {

--- a/registration/frontend/package.json
+++ b/registration/frontend/package.json
@@ -12,9 +12,12 @@
     "@sentry/solid": "^10.44.0",
     "@solid-primitives/context": "^0.3.2",
     "@solid-primitives/date": "^2.1.6",
+    "@solid-primitives/event-bus": "^1.1.3",
     "@solid-primitives/history": "^0.2.3",
     "@solid-primitives/memo": "^1.4.5",
     "@solid-primitives/presence": "^0.1.3",
+    "@syfaro/aamva-web": "^0.1.0",
+    "@syfaro/scanners-and-such-web": "^0.1.0",
     "@tanstack/solid-devtools": "^0.8.0",
     "@tanstack/solid-hotkeys": "^0.4.1",
     "@tanstack/solid-hotkeys-devtools": "^0.4.2",
@@ -29,6 +32,7 @@
     "lodash": "^4.17.23",
     "mitt": "^3.0.1",
     "mqtt": "^5.14.1",
+    "mrtd": "^1.0.0",
     "solid-fa": "^0.2.0",
     "solid-js": "^1.9.10"
   },
@@ -40,6 +44,7 @@
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/big.js": "^6.2.2",
     "@types/lodash": "^4.17.24",
+    "@types/w3c-web-hid": "^1.0.6",
     "baseline-browser-mapping": "^2.10.8",
     "eslint": "^9.39.1",
     "eslint-plugin-solid": "^0.14.5",
@@ -51,6 +56,7 @@
     "typescript-eslint": "^8.57.1",
     "vite": "^7.3.1",
     "vite-plugin-solid": "^2.11.11",
+    "vite-plugin-wasm": "^3.5.0",
     "vite-tsconfig-paths": "^6.1.1"
   }
 }

--- a/registration/frontend/src/admin/features/navbar/components/navbar.tsx
+++ b/registration/frontend/src/admin/features/navbar/components/navbar.tsx
@@ -132,6 +132,11 @@ export const Navbar: Component<{
                       key="searchBirthday"
                     />
 
+                    <ToggleSetting
+                      name="Enable Local Scanner"
+                      key="usesLocalScanner"
+                    />
+
                     <Show when={config()?.mqtt?.auth?.print_topic}>
                       <ToggleSetting
                         name="Auto Print After Payment"

--- a/registration/frontend/src/admin/features/onsite.tsx
+++ b/registration/frontend/src/admin/features/onsite.tsx
@@ -1,10 +1,14 @@
 import { toaster } from "@kobalte/core/toast";
+import { createEmitter } from "@solid-primitives/event-bus";
 import { useQuery, useQueryClient } from "@tanstack/solid-query";
 import {
   type Component,
   type Setter,
+  Show,
+  Suspense,
   createEffect,
   createSignal,
+  lazy,
   onCleanup,
   useContext,
 } from "solid-js";
@@ -22,7 +26,15 @@ import { ErrorCard } from "@components/error-card";
 import { SentryErrorBoundary } from "../../common";
 import { AttendeeSearch } from "./attendee-search";
 import { Cart } from "./cart";
-import { Scan } from "./scan";
+import { type IdData, Scan } from "./scan";
+
+export type BarcodeEmitter = {
+  rawScan: string;
+  idCard: IdData;
+  url: URL;
+};
+
+const BarcodeScanner = lazy(() => import("./scanner"));
 
 const KNOWN_PAYMENT_MESSAGES: Record<string, [string, ActionToastType]> = {
   payment_opened: ["Payment screen opened", "success"],
@@ -76,6 +88,8 @@ export const Onsite: Component<{
   const clearCart = useClearCart();
 
   const refresh = () => cart.refetch();
+
+  const emitter = createEmitter<BarcodeEmitter>();
 
   createEffect(() => {
     if (props.readyForNext) {
@@ -143,8 +157,15 @@ export const Onsite: Component<{
         >
           <Scan
             gotScannedName={gotScannedName}
+            emitter={emitter}
             readyForNext={props.readyForNext}
           />
+
+          <Show when={userSettings().settings().usesLocalScanner}>
+            <Suspense>
+              <BarcodeScanner emitter={emitter} />
+            </Suspense>
+          </Show>
         </SentryErrorBoundary>
       </div>
 

--- a/registration/frontend/src/admin/features/scan/components/scan.tsx
+++ b/registration/frontend/src/admin/features/scan/components/scan.tsx
@@ -1,4 +1,5 @@
 import { faBarcode, faXmark } from "@fortawesome/free-solid-svg-icons";
+import type { Emitter } from "@solid-primitives/event-bus";
 import { createHotkey } from "@tanstack/solid-hotkeys";
 import {
   type Component,
@@ -10,6 +11,7 @@ import {
 } from "solid-js";
 import { createStore } from "solid-js/store";
 
+import type { BarcodeEmitter } from "@admin/features/onsite";
 import { MqttContext } from "@admin/providers/mqtt-provider";
 import { IconAndLabel } from "@components/icon-and-label";
 
@@ -26,6 +28,7 @@ type ScanStore = {
 
 export const Scan: Component<{
   gotScannedName(name: string, birthday?: string): void;
+  emitter: Emitter<BarcodeEmitter>;
   readyForNext: boolean;
 }> = (props) => {
   const mqtt = useContext(MqttContext)!;
@@ -102,17 +105,28 @@ export const Scan: Component<{
     }
   };
 
+  const forwardRawScan = (payload: object | null) => {
+    if (payload && typeof payload === "string") {
+      props.emitter.emit("rawScan", payload);
+    }
+  };
+
   createEffect(() => {
     const m = mqtt();
 
     m?.emitter.on("notify/scan/url", setUrl);
     m?.emitter.on("notify/scan/id", setId);
     m?.emitter.on("notify/scan/shc", setShc);
+    m?.emitter.on("notify/scan/raw", forwardRawScan);
+
+    props.emitter.on("url", (url) => setStore("url", url.toString()));
+    props.emitter.on("idCard", setId);
 
     onCleanup(() => {
       m?.emitter.off("notify/scan/url", setUrl);
       m?.emitter.off("notify/scan/id", setId);
       m?.emitter.off("notify/scan/shc", setShc);
+      m?.emitter.off("notify/scan/raw", forwardRawScan);
     });
   });
 

--- a/registration/frontend/src/admin/features/scan/index.ts
+++ b/registration/frontend/src/admin/features/scan/index.ts
@@ -1,7 +1,7 @@
 export { Scan } from "./components/scan";
 
 export interface IdData {
-  documentType: string;
+  documentType: "AAMVA" | "MRTD";
   first: string;
   last: string;
   dob: string;

--- a/registration/frontend/src/admin/features/scanner/components/attached-device.tsx
+++ b/registration/frontend/src/admin/features/scanner/components/attached-device.tsx
@@ -1,0 +1,118 @@
+import { HidPosDevice, SnapiDevice } from "@syfaro/scanners-and-such-web";
+import {
+  type Component,
+  Show,
+  createEffect,
+  createResource,
+  createSignal,
+  onCleanup,
+} from "solid-js";
+
+import { type DeviceDriver, driverNameForDevice } from "..";
+
+export const AttachedDevice: Component<{
+  device: HIDDevice;
+  triggerRefresh: () => void;
+  emitRawScan: (value: string) => void;
+}> = (props) => {
+  const [connected, setConnected] = createSignal(true);
+
+  const processValue = (emit: (value: string) => void, value: Uint8Array) =>
+    emit(new TextDecoder("utf-8").decode(value));
+
+  const [device] = createResource<
+    DeviceDriver | undefined,
+    [HIDDevice, (value: string) => void, boolean],
+    DeviceDriver | undefined
+  >(
+    () => [props.device, props.emitRawScan, connected()],
+    async ([device, emit, connected], { value }) => {
+      if (value) {
+        await value.close();
+      }
+
+      if (import.meta.env.DEV) {
+        // Hot reload doesn't wait for disconnect and we can only open the
+        // device once.
+        while (device.opened) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+      }
+
+      if (!connected) return;
+
+      const driverName = driverNameForDevice(device);
+      if (!driverName) return;
+
+      let driver;
+      if (driverName === "snapi") {
+        driver = new SnapiDevice();
+        driver.start(device, (data) => {
+          if (data.type === "barcode") {
+            processValue(emit, data.value.data);
+          }
+        });
+      } else if (driverName === "usb-hid") {
+        driver = new HidPosDevice();
+        driver.start(device, (data) => {
+          processValue(emit, data.value);
+        });
+      }
+
+      return driver;
+    },
+  );
+
+  createEffect(() => {
+    if (!connected() && props.device.opened) {
+      device.latest?.close();
+    }
+  });
+
+  onCleanup(() => {
+    if (props.device.opened) {
+      device.latest?.close();
+    }
+  });
+
+  const forget = async () => {
+    await props.device.forget();
+    props.triggerRefresh();
+  };
+
+  return (
+    <div
+      class="card"
+      classList={{
+        "border-success": connected(),
+        "border-warning": !connected(),
+      }}
+    >
+      <div class="card-header">{props.device.productName}</div>
+      <div class="card-body mb-0">
+        <Show
+          when={connected()}
+          fallback={
+            <button
+              class="btn btn-info btn-sm me-1"
+              onClick={[setConnected, true]}
+            >
+              Connect
+            </button>
+          }
+        >
+          <button
+            class="btn btn-warning btn-sm me-1"
+            onClick={[setConnected, false]}
+          >
+            Disconnect
+          </button>
+        </Show>
+
+        <button class="btn btn-danger btn-sm me-1" onClick={forget}>
+          Forget
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/registration/frontend/src/admin/features/scanner/components/barcode-scanner.tsx
+++ b/registration/frontend/src/admin/features/scanner/components/barcode-scanner.tsx
@@ -1,0 +1,225 @@
+import {
+  faChevronDown,
+  faChevronLeft,
+  faKeyboard,
+} from "@fortawesome/free-solid-svg-icons";
+import type { Emitter } from "@solid-primitives/event-bus";
+import { decodeBarcode } from "@syfaro/aamva-web";
+import mrtd from "mrtd";
+import Fa from "solid-fa";
+import {
+  type Component,
+  For,
+  Show,
+  Suspense,
+  createEffect,
+  createResource,
+  createSignal,
+  onCleanup,
+} from "solid-js";
+
+import type { BarcodeEmitter } from "@admin/features/onsite";
+import type { AddressData, IdData } from "@admin/features/scan";
+import { IconAndLabel } from "@components/icon-and-label";
+
+import { HID_SUPPORTED, filterDevices, mrtdDate, requestHidDevice } from "..";
+import { AttachedDevice } from "./attached-device";
+
+const decodeAamva = (value: string): IdData => {
+  const data = decodeBarcode(value);
+
+  const id: IdData = {
+    documentType: "AAMVA",
+    first: data.name?.first ?? "",
+    last: data.name?.family ?? "",
+    dob: data.date_of_birth ?? "",
+    expiry: data.document_expiration_date ?? "",
+    address: undefined,
+  };
+
+  if (data.address) {
+    const address: AddressData = {
+      address: data.address.address_1,
+      address2: data.address.address_2 ?? "",
+      city: data.address.city,
+      state: data.address.jurisdiction_code,
+      ZIP: data.address.postal_code.substring(0, 5),
+      country: data.country === "UnitedStates" ? "US" : "",
+    };
+
+    id.address = address;
+  }
+
+  return id;
+};
+
+const decodeMrtd = (value: string): IdData => {
+  let lines = value.split("\n");
+  if (lines.length === 1) {
+    if (lines[0].length === 90) {
+      lines = [
+        lines[0].substring(0, 30),
+        lines[0].substring(30, 60),
+        lines[0].substring(60, 90),
+      ];
+    } else if (lines[0].length === 72) {
+      lines = [lines[0].substring(0, 36), lines[0].substring(36, 72)];
+    } else if (lines[0].length === 88) {
+      lines = [lines[0].substring(0, 44), lines[0].substring(44, 88)];
+    }
+  }
+  const data = mrtd.parse(lines.join("\n"));
+  return {
+    documentType: "MRTD",
+    first: data.name.secondary,
+    last: data.name.primary,
+    dob: mrtdDate(data.birthday, false).toISOString().slice(0, 10),
+    expiry: mrtdDate(data.expiry, true).toISOString().slice(0, 10),
+  };
+};
+
+export const BarcodeScanner: Component<{ emitter: Emitter<BarcodeEmitter> }> = (
+  props,
+) => {
+  const [show, setShow] = createSignal(false);
+
+  const [pairedHidDevices, { refetch }] = createResource(async () => {
+    if (!HID_SUPPORTED) {
+        return [];
+    }
+
+    return filterDevices(await navigator.hid.getDevices());
+  });
+
+  const disconnect = () => {
+    refetch();
+    setShow(true);
+  };
+
+  createEffect(() => {
+    if (pairedHidDevices.latest?.length === 0 && HID_SUPPORTED) {
+      setShow(true);
+    }
+  });
+
+  createEffect(() => {
+    if (HID_SUPPORTED) {
+      navigator.hid.addEventListener("connect", refetch);
+      navigator.hid.addEventListener("disconnect", disconnect);
+
+      onCleanup(() => {
+        navigator.hid.removeEventListener("connect", refetch);
+        navigator.hid.removeEventListener("disconnect", disconnect);
+      });
+    }
+  });
+
+  const pair = async () => {
+    if (await requestHidDevice()) {
+      refetch();
+    }
+  };
+
+  const decodeRawScan = (value: string) => {
+    if (value.startsWith("@")) {
+      try {
+        const id = decodeAamva(value);
+        props.emitter.emit("idCard", id);
+        return;
+      } catch (err) {
+        console.warn("data starting with @ was not aamva", err);
+      }
+    }
+
+    if (value.startsWith("http")) {
+      try {
+        const url = new URL(value);
+        props.emitter.emit("url", url);
+        return;
+      } catch (err) {
+        console.warn("data starting with http was not url", err);
+      }
+    }
+
+    try {
+      const id = decodeMrtd(value);
+      props.emitter.emit("idCard", id);
+      return;
+    } catch (err) {
+      console.warn("data was not mrtd", err);
+    }
+
+    console.warn("unknown data scanned");
+  };
+
+  createEffect(() => {
+    props.emitter.on("rawScan", decodeRawScan);
+  });
+
+  return (
+    <div class="card mb-3">
+      <div class="card-header">
+        <h5 class="card-heading mb-0">
+          <div class="row align-items-center g-1">
+            <div class="col">
+              <IconAndLabel children="Local Scanner" icon={faKeyboard} fw />
+            </div>
+
+            <div class="col-auto">
+              <button
+                class="btn btn-sm btn-secondary"
+                onClick={() => setShow((val) => !val)}
+              >
+                <Fa icon={show() ? faChevronDown : faChevronLeft} fw />
+              </button>
+            </div>
+          </div>
+        </h5>
+      </div>
+
+      <div class="collapse" classList={{ show: show() }}>
+        <Show
+          when={HID_SUPPORTED}
+          fallback={
+            <div class="card-body pb-0">
+              <div class="alert alert-warning">Web HID not supported</div>
+            </div>
+          }
+        >
+          <Suspense
+            fallback={
+              <div class="card-body pb-0">
+                <h2>Loading devices...</h2>
+              </div>
+            }
+          >
+            <For
+              each={pairedHidDevices()}
+              fallback={
+                <p class="card-body pb-0 mb-0">No paired devices found</p>
+              }
+            >
+              {(device) => (
+                <div class="card-body pb-0">
+                  <AttachedDevice
+                    device={device}
+                    triggerRefresh={refetch}
+                    emitRawScan={(value) => {
+                      props.emitter.emit("rawScan", value);
+                    }}
+                  />
+                </div>
+              )}
+            </For>
+
+            <div class="card-body">
+              <button class="btn btn-info me-1" onClick={() => pair()}>
+                Connect New Device
+              </button>
+            </div>
+          </Suspense>
+        </Show>
+      </div>
+    </div>
+  );
+};

--- a/registration/frontend/src/admin/features/scanner/index.tsx
+++ b/registration/frontend/src/admin/features/scanner/index.tsx
@@ -1,0 +1,78 @@
+/// <reference types="w3c-web-hid" />
+import { HidPosDevice, SnapiDevice } from "@syfaro/scanners-and-such-web";
+import { parse } from "date-fns/parse";
+import { type MRTDDate } from "mrtd";
+
+export { BarcodeScanner as default } from "./components/barcode-scanner";
+
+export type DeviceDriverName = "snapi" | "usb-hid";
+export type SupportedDevice = {
+  name: DeviceDriverName;
+  filters: HIDDeviceFilter[];
+};
+
+export type DeviceDriver = SnapiDevice | HidPosDevice;
+
+export const HID_SUPPORTED = "hid" in navigator;
+
+const SUPPORTED_DEVICES: SupportedDevice[] = [
+  { name: "snapi", filters: [{ vendorId: 0x05e0, productId: 0x1900 }] },
+  { name: "usb-hid", filters: [{ usagePage: 0x008c, usage: 0x0002 }] },
+];
+
+const ALL_FILTERS = SUPPORTED_DEVICES.flatMap(({ filters }) => filters);
+
+const checkDeviceFilter = (
+  device: HIDDevice,
+  filter: HIDDeviceFilter,
+): boolean => {
+  if (filter.vendorId && device.vendorId !== filter.vendorId) return false;
+  if (filter.productId && device.productId !== filter.productId) return false;
+  if (
+    filter.usagePage &&
+    !device.collections.some(
+      (collection) => collection.usagePage === filter.usagePage,
+    )
+  )
+    return false;
+  if (
+    filter.usage &&
+    !device.collections.some((collection) => collection.usage === filter.usage)
+  )
+    return false;
+
+  return true;
+};
+
+export const filterDevices = (devices: HIDDevice[]): HIDDevice[] => {
+  return devices.filter((device) =>
+    ALL_FILTERS.some((filter) => checkDeviceFilter(device, filter)),
+  );
+};
+
+export const driverNameForDevice = (
+  device: HIDDevice,
+): DeviceDriverName | undefined =>
+  SUPPORTED_DEVICES.find((supported_device) =>
+    supported_device.filters.some((filter) =>
+      checkDeviceFilter(device, filter),
+    ),
+  )?.name;
+
+export const requestHidDevice = async (): Promise<HIDDevice[]> => {
+  return await navigator.hid.requestDevice({
+    filters: ALL_FILTERS,
+  });
+};
+
+export const mrtdDate = (d: MRTDDate, allowFuture: boolean): Date => {
+  const [year, month, day] = [d.year, d.month, d.day].map((val) =>
+    val.toString().padStart(2, "0"),
+  );
+  const currentDate = new Date();
+  const val = parse(`${year}${month}${day}`, "yyMMdd", currentDate);
+  if (val.getFullYear() > currentDate.getFullYear() - 20 && !allowFuture) {
+    val.setFullYear(val.getFullYear() - 100);
+  }
+  return val;
+};

--- a/registration/frontend/src/admin/mqtt.ts
+++ b/registration/frontend/src/admin/mqtt.ts
@@ -22,6 +22,7 @@ export type MqttTopic =
   | "notify/info"
   | "notify/payment"
   | "notify/scan/id"
+  | "notify/scan/raw"
   | "notify/scan/shc"
   | "notify/scan/url"
   | "presence"

--- a/registration/frontend/src/admin/providers/user-settings-provider.tsx
+++ b/registration/frontend/src/admin/providers/user-settings-provider.tsx
@@ -12,7 +12,8 @@ export type UserSettingKey =
   | "multipleBadgeColumns"
   | "showSearchStatus"
   | "printAfterPayment"
-  | "searchBirthday";
+  | "searchBirthday"
+  | "usesLocalScanner";
 
 export type UserSettings = Record<UserSettingKey, boolean | undefined>;
 
@@ -22,6 +23,7 @@ const USER_DEFAULTS: UserSettings = {
   showSearchStatus: false,
   printAfterPayment: true,
   searchBirthday: true,
+  usesLocalScanner: false,
 };
 
 export class UserSettingsManager {

--- a/registration/frontend/src/mrtd.d.ts
+++ b/registration/frontend/src/mrtd.d.ts
@@ -1,0 +1,26 @@
+declare module "mrtd" {
+  declare type MRTD = {
+    birthday: MRTDDate;
+    documentNumber: string;
+    documentSubType: string;
+    documentType: string;
+    expiry: MRTDDate;
+    issuer: string;
+    name: MRTDName;
+    nationality: string;
+    sex: string;
+  };
+
+  declare type MRTDName = {
+    primary: string;
+    secondary: string;
+  };
+
+  declare type MRTDDate = {
+    year: string;
+    month: string;
+    day: string;
+  };
+
+  declare function parse(lines: string): MRTD;
+}

--- a/registration/frontend/vite.config.ts
+++ b/registration/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import devtools from "solid-devtools/vite";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
+import wasm from "vite-plugin-wasm";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
@@ -18,6 +19,7 @@ export default defineConfig({
       autoCodeSplitting: true,
     }),
     solid(),
+    wasm(),
   ],
   build: {
     manifest: "manifest.json",


### PR DESCRIPTION
This PR adds support for connecting Web HID scanners directly in the onsite admin. Being able to directly connect devices greatly simplifies setup on non-managed machines and provides instant feedback about if devices are correctly connected. Because it's in-browser it also means that we don't have to send PII through a server, it stays entirely on device until it's used.

It supports scanners using USB HID POS (Honeywell and hopefully others) or SNAPI (Zebra). Because the packet and AAMVA parsing code is somewhat large, it is lazy loaded only when this feature is enabled on the client. Once a scanner has been connected it will automatically reconnect on page load until it is manually forgotten.

The existing implementation of scanning handled SHC validation itself, which isn't feasible to do entirely client side with this feature. If we want to support this I'd need to add a new server endpoint to validate the data, but I'm not sure it's worth the time right now.

<img width="473" height="264" alt="Screenshot 2026-03-13 at 3 33 02 PM" src="https://github.com/user-attachments/assets/2b6e418b-b5d6-4328-b6a3-85a9a6ea4c32" />

Future features:
- Support Web Serial scanners (Web HID is Chromium only, Web Serial will be supported in Firefox in the future)