### PR TITLE
Add warning about staff reg date and auto check-in

### DIFF
--- a/registration/admin.py
+++ b/registration/admin.py
@@ -176,7 +176,9 @@ class TempTokenAdmin(admin.ModelAdmin):
 
 @admin.action(description="Send approval email and payment instructions")
 def send_approval_email(modeladmin, request, queryset):
-    tasks.send_dealer_approval_email_task.delay(list(queryset.values_list("id", flat=True)))
+    tasks.send_dealer_approval_email_task.delay(
+        list(queryset.values_list("id", flat=True))
+    )
     queryset.update(emailed=True)
     if queryset.count() > 1:
         messages.success(request, "Successfully emailed %d dealers" % queryset.count())
@@ -938,6 +940,12 @@ def generate_badge_labels(queryset, request, source, terminal):
             printed_badge_level = "Dealer"
         elif badge_type == "Staff":
             printed_badge_level = "Staff"
+
+            if source == PrintHistory.ONSITE:
+                staff = Staff.objects.get(attendee=badge.attendee, event=badge.event)
+                if not staff.checkedIn:
+                    staff.checkedIn = True
+                    staff.save()
 
         tags.append(
             {

--- a/registration/frontend/src/admin/api.ts
+++ b/registration/frontend/src/admin/api.ts
@@ -171,6 +171,7 @@ export type AttendeeOption = {
 
 export type Staff = {
   shirtSize: string;
+  beforeDeadline: boolean;
 };
 
 export type BadgePrintResponse = {

--- a/registration/frontend/src/admin/features/cart/components/cart-badge.tsx
+++ b/registration/frontend/src/admin/features/cart/components/cart-badge.tsx
@@ -1,4 +1,9 @@
-import { faPaw, faPrint, faTrash } from "@fortawesome/free-solid-svg-icons";
+import {
+  faPaw,
+  faPrint,
+  faTrash,
+  faTriangleExclamation,
+} from "@fortawesome/free-solid-svg-icons";
 import { ContextMenu } from "@kobalte/core/context-menu";
 import { useQueryClient } from "@tanstack/solid-query";
 import Fa from "solid-fa";
@@ -263,7 +268,22 @@ export const CartBadge: Component<{
                     <td colSpan={3}>
                       <span>
                         {`Staff Shirt – `}
-                        <span class="fw-semibold">
+                        <span
+                          class="fw-semibold"
+                          classList={{
+                            "text-danger": !props.badge.staff?.beforeDeadline,
+                          }}
+                          title={
+                            props.badge.staff?.beforeDeadline
+                              ? undefined
+                              : "Registered after deadline"
+                          }
+                        >
+                          <Show when={!props.badge.staff?.beforeDeadline}>
+                            <span>
+                              <Fa icon={faTriangleExclamation} fw />
+                            </span>
+                          </Show>
                           {props.badge.staff?.shirtSize || "None"}
                         </span>
                       </span>

--- a/registration/views/onsite_admin.py
+++ b/registration/views/onsite_admin.py
@@ -885,6 +885,7 @@ def build_result(cart):
 
             staff_data = {
                 "shirtSize": staff.shirtsize.name if staff.shirtsize else None,
+                "beforeDeadline": order.createdDate <= badge.event.staffRegEnd,
             }
 
         item = {

--- a/registration/views/printing.py
+++ b/registration/views/printing.py
@@ -17,7 +17,7 @@ from gotenberg_client.options import (
 )
 
 from registration import mqtt
-from registration.models import Badge, Dealer, Firebase, Staff, PrintHistory
+from registration.models import Badge, Dealer, Firebase, PrintHistory, Staff
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +90,15 @@ def pdfFromGotenberg(request: HttpRequest) -> Union[HttpResponse, JsonResponse]:
             )
 
         level = str(level)
-        if Staff.objects.filter(attendee=badge.attendee, event=badge.event).exists():
+        if staff := Staff.objects.filter(
+            attendee=badge.attendee, event=badge.event
+        ).first():
             level = "Staff"
+
+            if not staff.checkedIn and data_obj["source"] == PrintHistory.ONSITE:
+                staff.checkedIn = True
+                staff.save()
+
         elif Dealer.objects.filter(attendee=badge.attendee, event=badge.event).exists():
             level = "Dealer"
 
@@ -107,7 +114,7 @@ def pdfFromGotenberg(request: HttpRequest) -> Union[HttpResponse, JsonResponse]:
         pdfs = []
 
         for badge_template_id, badges in badge_groups.items():
-            (badge_template, template) = badge_templates[badge_template_id]
+            badge_template, template = badge_templates[badge_template_id]
             context = Context({"badges": badges})
             rendered = str(template.render(context))
 
@@ -168,7 +175,9 @@ def pdfFromGotenberg(request: HttpRequest) -> Union[HttpResponse, JsonResponse]:
     for badge in queryset:
         badge.printed = True
         badge.save()
-        PrintHistory.objects.create(badge=badge, firebase=terminal, source=data_obj["source"])
+        PrintHistory.objects.create(
+            badge=badge, firebase=terminal, source=data_obj["source"]
+        )
 
     if terminal:
         mqtt.send_mqtt_message(mqtt.get_topic("web/refresh", name=terminal.name))


### PR DESCRIPTION
This PR adds two features to staff handling. The first is automatically checking in staff when printing their badges. The second is when staff registered after the staff reg deadline, a warning is shown for their shirt size. We usually don't have shirts for staff that registered after the deadline.
<img width="427" height="57" alt="Screenshot 2026-03-13 at 5 34 43 PM" src="https://github.com/user-attachments/assets/a887b2fd-bb53-4a4b-9bc1-eeb979cf319b" />
