### PR TITLE
regression: fix order form validation error formatting

### DIFF
--- a/registration/tests/test_master.py
+++ b/registration/tests/test_master.py
@@ -23,12 +23,14 @@ class TestAttendeeCheckout(OrdersTestCase):
     def test_get_prices(self):
         response = self.client.post(
             reverse("registration:pricelevels"),
-            json.dumps({
-                "year": "1990",
-                "month": "1",
-                "day": "1",
-                "form_type": "attendee",
-            }),
+            json.dumps(
+                {
+                    "year": "1990",
+                    "month": "1",
+                    "day": "1",
+                    "form_type": "attendee",
+                }
+            ),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
@@ -89,6 +91,47 @@ class TestAttendeeCheckout(OrdersTestCase):
     def test_zero_checkout(self):
         # TODO
         pass
+
+    def test_checkout_invalid_billing_returns_400_with_errors(self):
+        self.add_to_cart(self.attendee_form_2, self.price_45, [])
+
+        # Omit some require billing data fields so OrderForm.is_valid() returns False
+        post_data = {
+            "billingData": {
+                "cc_firstname": "Buffy",
+                "cc_lastname": "Cleveland",
+                "address1": "123 Any Street",
+                "source_id": "cnon:card-nonce-ok",
+            },
+            "charityDonation": "0",
+            "orgDonation": "0",
+            "onsite": False,
+        }
+
+        response = self.client.post(
+            reverse("registration:checkout"),
+            json.dumps(post_data),
+            content_type="application/json",
+            headers={"idempotency-key": str(uuid.uuid4())},
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        body = response.json()
+        self.assertFalse(body["success"])
+        errors = body["reason"]["errors"]
+        self.assertIsInstance(errors, list)
+        self.assertGreater(len(errors), 0)
+
+        codes = [err["code"] for err in errors]
+        # ErrorDict is keyed by form so we should see at least one missing field
+        self.assertTrue(
+            any("billingEmail" in code for code in codes),
+            f"Expected billingEmail error, got: {codes}",
+        )
+
+        # No Attendee should be persisted when validation fails
+        self.assertEqual(Attendee.objects.filter(firstName="Bea").count(), 0)
 
     def assert_square_error(self, nonce, error):
         self.add_to_cart(self.attendee_form_2, self.price_45, [])

--- a/registration/views/ordering.py
+++ b/registration/views/ordering.py
@@ -50,7 +50,11 @@ def do_checkout(
     )
 
     if not form.is_valid():
-        return False, {"errors": [{"code": f"{k} - {v}"} for k, v in form.errors]}, None
+        return (
+            False,
+            {"errors": [{"code": f"{k} - {v}"} for k, v in form.errors.items()]},
+            None,
+        )
 
     order: Order = form.save(commit=False)
 
@@ -392,4 +396,6 @@ def notify_terminal(request, order):
                     {"badgeId": order_item.badge_id},
                 )
     except Exception:
-        logger.warning("Could not use terminal-token for post-checkout notification", exc_info=True)
+        logger.warning(
+            "Could not use terminal-token for post-checkout notification", exc_info=True
+        )


### PR DESCRIPTION
`form.errors` is Django's `ErrorDict`; iterating it yields keys, not tuples. Use `.items()` instead.

Regression has been showing anyone with billing form validation errors a 500.

Fixes Glitchtip 282.