### PR TITLE
Security: Various SonarQube fixes

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -71,7 +71,7 @@ jobs:
           cache-dependency-path: registration/frontend/package-lock.json
       - name: Install dependencies
         working-directory: registration/frontend
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build frontend
         working-directory: registration/frontend
         run: npm run build
@@ -132,7 +132,7 @@ jobs:
         with:
           enable-cache: true
       - name: Install Python dependencies
-        run: uv sync
+        run: uv sync --frozen --no-build
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -142,13 +142,13 @@ jobs:
       - name: Build frontend
         working-directory: registration/frontend
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build
       - name: Run Tests
         run: |
           cp fm_eventmanager/settings.py.ci fm_eventmanager/settings.py
-          uv run python ./manage.py collectstatic --noinput --skip-checks
-          uv run coverage run ./manage.py test registration
+          uv run --frozen --no-build --no-sync python ./manage.py collectstatic --noinput --skip-checks
+          uv run --frozen --no-build --no-sync coverage run ./manage.py test registration
         env:
           SQUARE_APPLICATION_ID: ${{ secrets.SQUARE_APPLICATION_ID }}
           SQUARE_ACCESS_TOKEN: ${{ secrets.SQUARE_ACCESS_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
           EMAIL_HOST_USER: ${{ secrets.EMAIL_HOST_USER }}
           EMAIL_HOST_PASSWORD: ${{ secrets.EMAIL_HOST_PASSWORD }}
       - name: Submit coverage
-        run: uv run coveralls --service=github
+        run: uv run --frozen --no-build --no-sync coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
@@ -169,7 +169,7 @@ jobs:
     container: python:3-alpine
     steps:
     - name: Install coveralls
-      run: pip3 install --upgrade coveralls
+      run: pip3 install --only-binary :all: coveralls==4.1.0
     - name: Finished
       run: coveralls --finish
       env:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -169,7 +169,7 @@ jobs:
     container: python:3-alpine
     steps:
     - name: Install coveralls
-      run: pip3 install --only-binary :all: coveralls==4.1.0
+      run: "pip3 install --only-binary=:all: coveralls==4.1.0"
     - name: Finished
       run: coveralls --finish
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV NODE_ENVIRONMENT=production
 WORKDIR /app/registration/frontend
 
 COPY ./registration/frontend/package.json ./registration/frontend/package-lock.json /app/registration/frontend/
-RUN npm install
+RUN npm ci --ignore-scripts
 COPY ./registration/frontend/ /app/registration/frontend/
 RUN npm run build
 
@@ -36,14 +36,14 @@ USER apis
 RUN --mount=type=cache,mode=0755,uid=1000,target=/app/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project
+    uv sync --frozen --no-build --no-install-project
 
 COPY --chown=apis . /app/
 COPY --chown=apis ./fm_eventmanager/settings.py.docker /app/fm_eventmanager/settings.py
 COPY --from=assets --chown=apis /app/registration/static/ /app/registration/static/
 
 RUN --mount=type=cache,mode=0755,uid=1000,target=/app/.cache/uv \
-    uv sync --frozen
+    uv sync --frozen --no-build
 
 RUN DJANGO_SECRET_KEY=collectstatic ./manage.py collectstatic --noinput
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "django-mathfilters~=1.0.0",
     "django-nested-admin>=4.1.1",
     "django-nested-inline~=0.4.6",
-    "django-prometheus~=2.4.1",
+    "django-prometheus~=2.5.0",
     "django-redis~=7.0.0",
     "django-vite>=3.1.0",
     "django-widget-tweaks~=1.5.1",
@@ -43,9 +43,6 @@ dependencies = [
     "uvicorn>=0.51.0",
     "uvicorn-worker>=0.4.0",
 ]
-
-[tool.uv.sources]
-django-prometheus = { git = "https://github.com/django-commons/django-prometheus", rev = "ea2d559476675a688f82cc37fac22b796ec7bcba" }
 
 [dependency-groups]
 dev = [

--- a/registration/views/dealers.py
+++ b/registration/views/dealers.py
@@ -12,6 +12,7 @@ from django.http import (
 )
 from django.shortcuts import render
 from django.urls import reverse
+from django.views.decorators.http import require_GET
 
 import registration.emails
 from registration.models import *
@@ -615,6 +616,7 @@ def addNewDealer(request):
     return JsonResponse({"success": True})
 
 
+@require_GET
 def getTableSizes(request):  # noqa: S1172, S1542 removing parameter will break django
     event = Event.objects.get(default=True)
     sizes = TableSize.objects.filter(event=event)

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "django-mathfilters", specifier = "~=1.0.0" },
     { name = "django-nested-admin", specifier = ">=4.1.1" },
     { name = "django-nested-inline", specifier = "~=0.4.6" },
-    { name = "django-prometheus", git = "https://github.com/django-commons/django-prometheus?rev=ea2d559476675a688f82cc37fac22b796ec7bcba" },
+    { name = "django-prometheus", specifier = "~=2.5.0" },
     { name = "django-redis", specifier = "~=7.0.0" },
     { name = "django-vite", specifier = ">=3.1.0" },
     { name = "django-widget-tweaks", specifier = "~=1.5.1" },
@@ -640,11 +640,15 @@ wheels = [
 
 [[package]]
 name = "django-prometheus"
-version = "2.5.0.dev0"
-source = { git = "https://github.com/django-commons/django-prometheus?rev=ea2d559476675a688f82cc37fac22b796ec7bcba#ea2d559476675a688f82cc37fac22b796ec7bcba" }
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/c7/dc39c4c19f7b35e827a486d08376de1fad31c50decb26c56e32668314f13/django_prometheus-2.5.0.tar.gz", hash = "sha256:4837b3c3734d8350880839ab8235aafd250b668c348e159d4aecc3cbefeee53e", size = 26465, upload-time = "2026-05-26T19:04:00.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5d/6ec3083ba69545696c962ae505a0e52e280e7592d4c278c2f3803cabb688/django_prometheus-2.5.0-py2.py3-none-any.whl", hash = "sha256:f15efb526cd53f9cf12da72dc55506322f5566b017a819ff27be1da302303134", size = 31801, upload-time = "2026-05-26T19:03:59.505Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Various sonarqube CWE fixes mostly around dependency managment:

- Replace `npm install` with `npm ci --ignore-scripts` in Dockerfile and CI workflows for reproducible builds
- Add `--frozen` and `--no-build` flags to `uv sync` commands to prevent unintended dependency updates
- Upgrade django-prometheus from git-pinned dev version to stable 2.5.0 release
- Add `@require_GET` decorator
- Pin coveralls version
- Improve build reproducibility