### PR TITLE
(security): remove information exposure in logging, improve staff save error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 fm_eventmanager/dev.py
 fm_eventmanager/settings.py
 fm_eventmanager/settings.py.bak
-^static/
+static/
 venv/
 db.sqlite3
 test-db.sqlite3

--- a/registration/tests/test_staff.py
+++ b/registration/tests/test_staff.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
+from django.db import DatabaseError, IntegrityError
 from django.test import TestCase
 from django.test.utils import tag
 from django.urls import reverse
@@ -133,7 +135,9 @@ class TestNewStaff(StaffTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"not yet open", response.content)
-        self.assertIn(b'<a href="/registration/">Back to Main Page</a>', response.content)
+        self.assertIn(
+            b'<a href="/registration/">Back to Main Page</a>', response.content
+        )
 
     @freeze_time(timezone.now() + timedelta(days=20))
     def test_new_staff_invite_good_closed_ended(self):
@@ -148,7 +152,9 @@ class TestNewStaff(StaffTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"has ended", response.content)
-        self.assertIn(b'<a href="/registration/">Back to Main Page</a>', response.content)
+        self.assertIn(
+            b'<a href="/registration/">Back to Main Page</a>', response.content
+        )
 
     @freeze_time("2000-01-01")
     def test_new_staff_invite_override(self):
@@ -284,19 +290,25 @@ class TestAddNewStaff(StaffTestCase):
 
 class TestReturningStaff(StaffTestCase):
     def test_returning_staff(self):
-        response = self.client.get(reverse("registration:returning_staff", args=("foo",)))
+        response = self.client.get(
+            reverse("registration:returning_staff", args=("foo",))
+        )
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(b"not yet open", response.content)
 
     @freeze_time(timezone.now() - timedelta(days=20))
     def test_returning_staff_closed_upcoming(self):
-        response = self.client.get(reverse("registration:returning_staff", args=("foo",)))
+        response = self.client.get(
+            reverse("registration:returning_staff", args=("foo",))
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"not yet open", response.content)
 
     @freeze_time(timezone.now() + timedelta(days=20))
     def test_returning_staff_closed_ended(self):
-        response = self.client.get(reverse("registration:returning_staff", args=("foo",)))
+        response = self.client.get(
+            reverse("registration:returning_staff", args=("foo",))
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"has ended", response.content)
 
@@ -518,3 +530,193 @@ class TestStaffEmail(StaffTestCase):
         self.event.save()
         email = staff.get_staff_email()
         self.assertEqual(email, settings.APIS_DEFAULT_EMAIL)
+
+
+class TestAddReturningStaffBranches(StaffTestCase):
+    """
+    Test sad paths for add_returning_staff
+    """
+
+    def setUp(self):
+        super().setUp()
+        session = self.client.session
+        session["staff_id"] = self.staff.id
+        session.save()
+
+    def _build_payload(self, **overrides):
+        payload = {
+            "attendee": {
+                "id": self.attendee.id,
+                "firstName": "Staffer",
+                "lastName": "Testerson",
+                "address1": "123 Somewhere St",
+                "address2": "",
+                "city": "Place",
+                "state": "PA",
+                "country": "US",
+                "postal": "12345",
+                "phone": "1112223333",
+                "email": "apis@mailinator.com",
+                "birthdate": "1990-01-01",
+                "badgeName": "FluffyButz",
+                "emailsOk": "true",
+            },
+            "staff": {
+                "id": self.staff.id,
+                "department": self.department1.id,
+                "title": "Something Cool",
+                "twitter": "@twitstaff",
+                "telegram": "@twitstaffagain",
+                "shirtsize": self.shirt1.id,
+                "specialSkills": "Something here",
+                "specialFood": "no water please",
+                "specialMedical": "alerigic to bandaids",
+                "contactPhone": "4442223333",
+                "contactName": "Test Testerson",
+                "contactRelation": "Pet",
+            },
+            "priceLevel": {
+                "id": self.price_150.id,
+                "options": [
+                    {"id": self.option_100_int.id, "value": 1},
+                    {"id": self.option_shirt.id, "value": self.shirt1.id},
+                ],
+            },
+            "event": self.event.name,
+        }
+        # Shallow-merge overrides into nested dicts so tests can tweak
+        # just a couple of keys without repeating the whole payload.
+        for key, value in overrides.items():
+            if (
+                isinstance(value, dict)
+                and key in payload
+                and isinstance(payload[key], dict)
+            ):
+                payload[key].update(value)
+            else:
+                payload[key] = value
+        return payload
+
+    def _post(self, payload=None):
+        body = (
+            payload
+            if isinstance(payload, str)
+            else json.dumps(self._build_payload() if payload is None else payload)
+        )
+        return self.client.post(
+            reverse("registration:add_returning_staff"),
+            body,
+            content_type="application/json",
+        )
+
+    def test_bad_json_returns_false(self):
+        response = self._post("not valid json{{{")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": False})
+
+    def test_uses_default_event_when_no_event_key(self):
+        payload = self._build_payload()
+        del payload["event"]
+        response = self._post(payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+
+    def test_attendee_not_found(self):
+        payload = self._build_payload(attendee={"id": 9999999})
+        response = self._post(payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"success": False, "message": "Attendee not found"},
+        )
+
+    def test_missing_staff_id_in_session(self):
+        session = self.client.session
+        session.pop("staff_id", None)
+        session.save()
+        response = self._post()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"success": False, "message": "Staff record not found"},
+        )
+
+    def test_staff_record_not_found(self):
+        payload = self._build_payload(staff={"id": 9999999})
+        response = self._post(payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"success": False, "message": "Staff record not found"},
+        )
+
+    def test_new_badge_created_when_none_exists(self):
+        # attendee2 has a badge from setUp; delete it to hit the create branch
+        Badge.objects.filter(attendee=self.attendee2, event=self.event).delete()
+        session = self.client.session
+        session["staff_id"] = self.staff2.id
+        session.save()
+        payload = self._build_payload(
+            attendee={"id": self.attendee2.id},
+            staff={"id": self.staff2.id},
+        )
+        response = self._post(payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+        badges = Badge.objects.filter(attendee=self.attendee2, event=self.event)
+        self.assertEqual(badges.count(), 1)
+        self.assertEqual(badges.first().badgeName, "FluffyButz")
+
+    def test_existing_badge_reused_and_renamed(self):
+        # self.badge is created for self.attendee in StaffTestCase.setUp
+        self.assertEqual(self.badge.badgeName, "DisStaff")
+        payload = self._build_payload(attendee={"badgeName": "NewName"})
+        response = self._post(payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+        badges = Badge.objects.filter(attendee=self.attendee, event=self.event)
+        self.assertEqual(badges.count(), 1)
+        self.assertEqual(badges.first().badgeName, "NewName")
+
+    def test_integrity_error_returns_409_and_rolls_back(self):
+        original_first_name = self.attendee.firstName
+        payload = self._build_payload(attendee={"firstName": "RolledBack"})
+        with patch.object(
+            staff, "staff_from_post_data", side_effect=IntegrityError("dup")
+        ):
+            response = self._post(payload)
+        self.assertEqual(response.status_code, 409)
+        body = response.json()
+        self.assertFalse(body["success"])
+        self.assertIn("conflicts", body["message"])
+        # transaction.atomic should have rolled back the attendee.save()
+        self.attendee.refresh_from_db()
+        self.assertEqual(self.attendee.firstName, original_first_name)
+        # and no OrderItem should have been created
+        self.assertFalse(OrderItem.objects.filter(badge=self.badge).exists())
+
+    def test_database_error_returns_503(self):
+        with patch.object(
+            staff, "staff_from_post_data", side_effect=DatabaseError("timeout")
+        ):
+            response = self._post()
+        self.assertEqual(response.status_code, 503)
+        body = response.json()
+        self.assertFalse(body["success"])
+        self.assertIn("Please try again", body["message"])
+
+    def test_no_discount_in_session_when_event_has_no_staff_discount(self):
+        self.event.staffDiscount = None
+        self.event.save()
+        response = self._post()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+        self.assertNotIn("discount", self.client.session)
+
+    def test_happy_path_populates_session(self):
+        response = self._post()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+        session = self.client.session
+        self.assertEqual(len(session["order_items"]), 1)
+        self.assertEqual(session["discount"], self.staffdiscount.codeName)

--- a/registration/views/staff.py
+++ b/registration/views/staff.py
@@ -1,12 +1,13 @@
 import json
 import logging
 from datetime import datetime
-from time import timezone
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import DatabaseError, IntegrityError, transaction
 from django.forms import model_to_dict
 from django.http import JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
 from django.views.decorators.http import require_POST
 
 from registration.models import *
@@ -206,7 +207,9 @@ def info_returning_staff(request):
 
     staff_id = request.session.get("staff_id")
     if staff_id is None:
-        return render(request, "registration/staff/returning-staff-payment.html", context)
+        return render(
+            request, "registration/staff/returning-staff-payment.html", context
+        )
 
     staff = Staff.objects.get(id=staff_id)
     if staff:
@@ -250,8 +253,9 @@ def add_returning_staff(request):
     else:
         event = Event.objects.get(default=True)
 
-    attendee = Attendee.objects.get(id=pda["id"])
-    if not attendee:
+    try:
+        attendee = Attendee.objects.get(id=pda["id"])
+    except Attendee.DoesNotExist:
         return JsonResponse({"success": False, "message": "Attendee not found"})
 
     tz = timezone.get_current_timezone()
@@ -271,27 +275,15 @@ def add_returning_staff(request):
     attendee.emailsOk = True
     attendee.surveyOk = False  # staff get their own survey
 
-    try:
-        attendee.save()
-    except Exception as e:
-        logger.exception("Error saving staff attendee record.")
-        return JsonResponse({"success": False, "message": "Attendee not saved: " + e})
-
-    staff = Staff.objects.get(id=pds["id"])
     if "staff_id" not in request.session:
         return JsonResponse({"success": False, "message": "Staff record not found"})
 
-    # Update Staff info
-    if not staff:
+    try:
+        staff = Staff.objects.get(id=pds["id"])
+    except Staff.DoesNotExist:
         return JsonResponse({"success": False, "message": "Staff record not found"})
 
-    staff_from_post_data(pds, attendee, event, staff)
-
-    try:
-        staff.save()
-    except Exception as e:
-        logger.exception("Error saving staff record.")
-        return JsonResponse({"success": False, "message": "Staff not saved: " + str(e)})
+    price_level = PriceLevel.objects.get(id=int(pdp["id"]))
 
     badges = Badge.objects.filter(attendee=attendee, event=event)
     if badges.count() == 0:
@@ -301,18 +293,33 @@ def add_returning_staff(request):
         badge.badgeName = pda["badgeName"]
 
     try:
-        badge.save()
-    except Exception as e:
-        logger.exception("Error saving staff badge record.")
-        return JsonResponse({"success": False, "message": "Badge not saved: " + str(e)})
-
-    price_level = PriceLevel.objects.get(id=int(pdp["id"]))
-
-    order_item = OrderItem.objects.create(
-        badge=badge, priceLevel=price_level, enteredBy="WEB"
-    )
-
-    CreateAttendeeOptions(order_item).save_options(pdp["options"])
+        with transaction.atomic():
+            attendee.save()
+            staff_from_post_data(pds, attendee, event, staff)
+            badge.save()
+            order_item = OrderItem.objects.create(
+                badge=badge, priceLevel=price_level, enteredBy="WEB"
+            )
+            CreateAttendeeOptions(order_item).save_options(pdp["options"])
+            staff.resetToken()
+    except IntegrityError:
+        logger.warning("Staff registration rejected by DB constraint", exc_info=True)
+        return JsonResponse(
+            {
+                "success": False,
+                "message": "Could not save: data conflicts with an existing record.",
+            },
+            status=409,
+        )
+    except DatabaseError:
+        logger.exception("Database error during staff registration")
+        return JsonResponse(
+            {
+                "success": False,
+                "message": "Could not save right now. Please try again.",
+            },
+            status=503,
+        )
 
     order_items = request.session.get("order_items", [])
     order_items.append(order_item.id)
@@ -322,23 +329,7 @@ def add_returning_staff(request):
     if discount:
         request.session["discount"] = discount.codeName
 
-    staff.resetToken()
-
     return JsonResponse({"success": True})
-
-
-def get_staff_total(orderItems, discount, staff):
-    badge = Badge.objects.get(attendee=staff.attendee, event=staff.event)
-
-    if badge.effectiveLevel():
-        discount = None
-    sub_total = get_total(orderItems, discount)
-    already_paid = badge.paidTotal()
-    total = sub_total - already_paid
-
-    if total < 0:
-        return 0
-    return total
 
 
 def get_staff_email(event=None):

--- a/registration/views/staff.py
+++ b/registration/views/staff.py
@@ -238,7 +238,7 @@ def info_returning_staff(request):
 def add_returning_staff(request):
     try:
         postData = json.loads(request.body)
-    except ValueError as e:
+    except ValueError:
         logger.error("Unable to decode JSON for add_returning_staff()")
         return JsonResponse({"success": False})
 


### PR DESCRIPTION
Fixes remaining GH security findings for staff views.

- Better exception handling pattern on save instead of swallowing `Exception`.
- Wrap writes in atomic transaction so failures roll back the entire flow
- Generic client response messages
- Session mutations moved after transaction so rollback doesn't leave that stale
- Remove dead code
- Add test coverage for branches of `add_returning_staff`